### PR TITLE
Add `create_raw_transaction*`

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -348,10 +348,40 @@ impl Client {
         self.call("listunspent", handle_defaults(&mut args, &defaults))
     }
 
+    pub fn create_raw_transaction_hex(
+        &mut self,
+        utxos: &[json::CreateRawTransactionInput],
+        outs: Option<&std::collections::HashMap<String, f64>>,
+        locktime: Option<i64>,
+        replaceable: Option<bool>,
+    ) -> Result<String> {
+        let mut args = [
+            into_json(utxos)?,
+            opt_into_json(outs)?,
+            opt_into_json(locktime)?,
+            opt_into_json(replaceable)?,
+        ];
+        let defaults =
+            [into_json::<&[json::CreateRawTransactionInput]>(&[])?, into_json(0i64)?, null()];
+        self.call("createrawtransaction", handle_defaults(&mut args, &defaults))
+    }
+
+    pub fn create_raw_transaction(
+        &mut self,
+        utxos: &[json::CreateRawTransactionInput],
+        outs: Option<&std::collections::HashMap<String, f64>>,
+        locktime: Option<i64>,
+        replaceable: Option<bool>,
+    ) -> Result<Transaction> {
+        let hex: String = self.create_raw_transaction_hex(utxos, outs, locktime, replaceable)?;
+        let bytes = hex::decode(hex)?;
+        Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
+    }
+
     pub fn sign_raw_transaction(
         &self,
         tx: json::HexBytes,
-        utxos: Option<&[json::UTXO]>,
+        utxos: Option<&[json::SignRawTransactionInput]>,
         private_keys: Option<&[&str]>,
         sighash_type: Option<json::SigHashType>,
     ) -> Result<json::SignRawTransactionResult> {
@@ -361,7 +391,11 @@ impl Client {
             opt_into_json(private_keys)?,
             opt_into_json(sighash_type)?,
         ];
-        let defaults = [into_json::<&[json::UTXO]>(&[])?, into_json::<&[&str]>(&[])?, null()];
+        let defaults = [
+            into_json::<&[json::SignRawTransactionInput]>(&[])?,
+            into_json::<&[&str]>(&[])?,
+            null(),
+        ];
         self.call("signrawtransaction", handle_defaults(&mut args, &defaults))
     }
 
@@ -372,11 +406,11 @@ impl Client {
     pub fn sign_raw_transaction_with_wallet(
         &self,
         tx: json::HexBytes,
-        utxos: Option<&[json::UTXO]>,
+        utxos: Option<&[json::SignRawTransactionInput]>,
         sighash_type: Option<json::SigHashType>,
     ) -> Result<json::SignRawTransactionResult> {
         let mut args = [into_json(tx)?, opt_into_json(utxos)?, opt_into_json(sighash_type)?];
-        let defaults = [into_json::<&[json::UTXO]>(&[])?, null()];
+        let defaults = [into_json::<&[json::SignRawTransactionInput]>(&[])?, null()];
         self.call("signrawtransactionwithwallet", handle_defaults(&mut args, &defaults))
     }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -517,14 +517,26 @@ impl serde::Serialize for SigHashType {
     }
 }
 
-// Used for signrawtransaction argument.
+// Used for createrawtransaction argument.
 #[derive(Serialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct UTXO<'a> {
-    pub txid: &'a Sha256dHash,
+pub struct CreateRawTransactionInput {
+    pub txid: Sha256dHash,
     pub vout: u32,
-    pub script_pub_key: &'a Script,
-    pub redeem_script: &'a Script,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sequence: Option<u32>,
+}
+
+// Used for signrawtransaction argument.
+#[derive(Serialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SignRawTransactionInput {
+    pub txid: Sha256dHash,
+    pub vout: u32,
+    pub script_pub_key: Script,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redeem_script: Option<Script>,
+    pub amount: f64,
 }
 
 /// Used to represent an address type.


### PR DESCRIPTION
To get this done:

* Remove too many references. It's really inconvenient to prepare a &[Smth<'a>].
  One reference is enough to avoid copying.
* Split and fix arguments of `signrawtransaction` and `createrawtransaction`.
  I have some code that I'm porting to this, that exercise it, so I'm convinced
  that they were wrong before. I'm unsure about the `*withwallet` though.