### PR TITLE
Better handle hex values as bytes

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -16,8 +16,6 @@ use hex;
 use jsonrpc;
 use serde_json;
 
-use json::GetterError;
-
 /// The error type for errors produced in this library.
 #[derive(Debug)]
 pub enum Error {
@@ -48,15 +46,6 @@ impl From<serde_json::error::Error> for Error {
 impl From<bitcoin::consensus::encode::Error> for Error {
     fn from(e: bitcoin::consensus::encode::Error) -> Error {
         Error::BitcoinSerialization(e)
-    }
-}
-
-impl From<GetterError> for Error {
-    fn from(e: GetterError) -> Error {
-        match e {
-            GetterError::FromHex(e) => Error::FromHex(e),
-            GetterError::BitcoinSerialization(e) => Error::BitcoinSerialization(e),
-        }
     }
 }
 

--- a/client/src/queryable.rs
+++ b/client/src/queryable.rs
@@ -12,8 +12,8 @@ use bitcoin;
 use serde_json;
 
 use bitcoin_hashes::sha256d;
-use client::RpcApi;
 use client::Result;
+use client::RpcApi;
 
 /// A type that can be queried from Bitcoin Core.
 pub trait Queryable<C: RpcApi>: Sized {

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -18,8 +18,7 @@ name = "bitcoincore_rpc_json"
 path = "src/lib.rs"
 
 [dependencies]
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 hex = "0.3"
 

--- a/json/src/getters.rs
+++ b/json/src/getters.rs
@@ -8,95 +8,47 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use std::fmt;
-use std::error;
-
 use bitcoin::consensus::encode as btc_encode;
 use bitcoin::{Script, Transaction};
-use hex;
 
 use super::*;
 
-/// The error type for errors produced in this library.
-#[derive(Debug)]
-pub enum GetterError {
-    FromHex(hex::FromHexError),
-    BitcoinSerialization(bitcoin::consensus::encode::Error),
-}
-
-impl From<hex::FromHexError> for GetterError {
-    fn from(e: hex::FromHexError) -> GetterError {
-        GetterError::FromHex(e)
-    }
-}
-
-impl From<bitcoin::consensus::encode::Error> for GetterError {
-    fn from(e: bitcoin::consensus::encode::Error) -> GetterError {
-        GetterError::BitcoinSerialization(e)
-    }
-}
-
-impl fmt::Display for GetterError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            GetterError::FromHex(ref e) => write!(f, "hex decode error: {}", e),
-            GetterError::BitcoinSerialization(ref e) => write!(f, "Bitcoin serialization error: {}", e),
-        }
-    }
-}
-
-impl error::Error for GetterError {
-    fn description(&self) -> &str {
-        match *self {
-            GetterError::FromHex(_) => "hex decode error",
-            GetterError::BitcoinSerialization(_) => "Bitcoin serialization error",
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            GetterError::FromHex(ref e) => Some(e),
-            GetterError::BitcoinSerialization(ref e) => Some(e),
-        }
-    }
-}
-
 /// Retrieve a relevant Script for the type.
 pub trait GetScript {
-    fn script(&self) -> Result<Script, GetterError>;
+    fn script(&self) -> Result<Script, btc_encode::Error>;
 }
 
 impl GetScript for GetRawTransactionResultVinScriptSig {
-    fn script(&self) -> Result<Script, GetterError> {
-        Ok(Script::from(hex::decode(&self.hex)?))
+    fn script(&self) -> Result<Script, btc_encode::Error> {
+        Ok(Script::from(self.hex.clone()))
     }
 }
 
 impl GetScript for GetRawTransactionResultVoutScriptPubKey {
-    fn script(&self) -> Result<Script, GetterError> {
-        Ok(Script::from(hex::decode(&self.hex)?))
+    fn script(&self) -> Result<Script, btc_encode::Error> {
+        Ok(Script::from(self.hex.clone()))
     }
 }
 
 /// Retrieve a relevant Transaction for the type.
 pub trait GetTransaction {
-    fn transaction(&self) -> Result<Transaction, GetterError>;
+    fn transaction(&self) -> Result<Transaction, btc_encode::Error>;
 }
 
 impl GetTransaction for GetRawTransactionResult {
-    fn transaction(&self) -> Result<Transaction, GetterError> {
-        Ok(btc_encode::deserialize(&hex::decode(&self.hex)?)?)
+    fn transaction(&self) -> Result<Transaction, btc_encode::Error> {
+        Ok(btc_encode::deserialize(&self.hex)?)
     }
 }
 
 impl GetTransaction for GetTransactionResult {
-    fn transaction(&self) -> Result<Transaction, GetterError> {
-        Ok(btc_encode::deserialize(&hex::decode(&self.hex)?)?)
+    fn transaction(&self) -> Result<Transaction, btc_encode::Error> {
+        Ok(btc_encode::deserialize(&self.hex)?)
     }
 }
 
 impl GetTransaction for SignRawTransactionResult {
-    fn transaction(&self) -> Result<Transaction, GetterError> {
-        Ok(btc_encode::deserialize(&hex::decode(&self.hex)?)?)
+    fn transaction(&self) -> Result<Transaction, btc_encode::Error> {
+        Ok(btc_encode::deserialize(&self.hex)?)
     }
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -22,6 +22,9 @@ extern crate bitcoin_hashes;
 extern crate hex;
 extern crate num_bigint;
 extern crate secp256k1;
+// `macro_use` is needed for v1.24.0 compilation.
+#[allow(unused)]
+#[macro_use]
 extern crate serde;
 extern crate serde_json;
 
@@ -62,12 +65,13 @@ pub mod serde_hex {
 
     pub mod opt {
         use hex;
-        use serde::{de::Error, Deserializer, Serializer};
+        use serde::de::Error;
+        use serde::{Deserializer, Serializer};
 
         pub fn serialize<S: Serializer>(b: &Option<Vec<u8>>, s: S) -> Result<S::Ok, S::Error> {
-            match b {
+            match *b {
                 None => s.serialize_none(),
-                Some(b) => s.serialize_str(&hex::encode(&b)),
+                Some(ref b) => s.serialize_str(&hex::encode(&b)),
             }
         }
 


### PR DESCRIPTION
Basically replaces all remaining strings that are actually hex representations of bytes into `Vec<u8>`.