### PR TITLE
Use bitcoin::PublicKey instead of secp256k1

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -25,5 +25,4 @@ hex = "0.3"
 bitcoin = { version = "0.17", features = [ "serde-decimal" ] }
 bitcoin_hashes = "0.3"
 bitcoin-amount = { version = "0.1.4", features = [ "serde" ] }
-secp256k1 = { version = "0.12", features = [ "serde" ] }
 num-bigint = { version = "0.2", features = [ "serde" ] }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -21,7 +21,6 @@ extern crate bitcoin_amount;
 extern crate bitcoin_hashes;
 extern crate hex;
 extern crate num_bigint;
-extern crate secp256k1;
 // `macro_use` is needed for v1.24.0 compilation.
 #[allow(unused)]
 #[macro_use]
@@ -33,12 +32,10 @@ pub use getters::*;
 
 use std::str::FromStr;
 
-use bitcoin::blockdata::script::Script;
-use bitcoin::util::address::Address;
+use bitcoin::{Address, Script, PublicKey};
 use bitcoin_amount::Amount;
 use bitcoin_hashes::sha256d;
 use num_bigint::BigUint;
-use secp256k1::PublicKey;
 use serde::de::Error as SerdeError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;


### PR DESCRIPTION
Fixes https://github.com/rust-bitcoin/rust-bitcoincore-rpc/issues/23.

serde serialization for PublicKey is not in rust-bitcoin v0.18.0, so we need to wait for a new rust-bitcoin release for this to work. So this one is stale until that release happens.