### PR TITLE
Have Client implement fmt::Debug

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -9,7 +9,7 @@
 //
 
 use std::fs::File;
-use std::result;
+use std::{fmt, result};
 
 use bitcoin;
 use hex;
@@ -652,6 +652,16 @@ pub trait RpcApi: Sized {
 /// Client implements a JSON-RPC client for the Bitcoin Core daemon or compatible APIs.
 pub struct Client {
     client: jsonrpc::client::Client,
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "bitcoincore_rpc::Client(jsonrpc::Client(last_nonce={}))",
+            self.client.last_nonce()
+        )
+    }
 }
 
 impl Client {


### PR DESCRIPTION
Just prints the only information we have available. (jsonrpc::Client doesn't implement Debug, which is why we didn't just derive it in the first place.)