### PR TITLE
Export dependent modules used in API

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,8 +26,3 @@ jsonrpc = "0.11"
 # Used for deserialization of JSON.
 serde = "1"
 serde_json = "1"
-hex = "0.3"
-
-# Used for Bitcoin-specific types.
-bitcoin = { version = "0.19.1", features = [ "use-serde" ] }
-num-bigint = { version = "0.2", features = [ "serde" ] }

--- a/client/examples/retry_client.rs
+++ b/client/examples/retry_client.rs
@@ -8,7 +8,6 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-extern crate bitcoin;
 extern crate bitcoincore_rpc;
 extern crate jsonrpc;
 extern crate serde;

--- a/client/examples/test_against_node.rs
+++ b/client/examples/test_against_node.rs
@@ -10,10 +10,9 @@
 
 //! A very simple example used as a self-test of this library against a Bitcoin
 //! Core node.
-extern crate bitcoin;
 extern crate bitcoincore_rpc;
 
-use bitcoincore_rpc::{Auth, Client, Error, RpcApi};
+use bitcoincore_rpc::{bitcoin, Auth, Client, Error, RpcApi};
 
 fn main_result() -> Result<(), Error> {
     let mut args = std::env::args();

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -18,10 +18,7 @@
 
 #[macro_use]
 extern crate log;
-extern crate bitcoin;
-extern crate hex;
 extern crate jsonrpc;
-extern crate num_bigint;
 #[allow(unused)]
 #[macro_use] // `macro_use` is needed for v1.24.0 compilation.
 extern crate serde;
@@ -29,6 +26,9 @@ extern crate serde_json;
 
 pub extern crate bitcoincore_rpc_json;
 pub use bitcoincore_rpc_json as json;
+pub use json::bitcoin;
+pub use json::hex;
+pub use json::num_bigint;
 
 mod client;
 mod error;

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -16,9 +16,9 @@
 #![crate_name = "bitcoincore_rpc_json"]
 #![crate_type = "rlib"]
 
-extern crate bitcoin;
-extern crate hex;
-extern crate num_bigint;
+pub extern crate bitcoin;
+pub extern crate hex;
+pub extern crate num_bigint;
 #[allow(unused)]
 #[macro_use] // `macro_use` is needed for v1.24.0 compilation.
 extern crate serde;


### PR DESCRIPTION
Somehow the build for Rust v1.24 is broken. I don't really understand how. It's unrelated to this PR, though.

Closes https://github.com/rust-bitcoin/rust-bitcoincore-rpc/issues/50.