### PR TITLE
update Bip9SoftforkInfo struct to work on regtest 0.19.1

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -459,12 +459,11 @@ pub struct Bip9SoftforkStatistics {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct Bip9SoftforkInfo {
     pub status: Bip9SoftforkStatus,
-    pub bit: u8,
-    #[serde(rename = "startTime")]
+    pub bit: Option<u8>,
     pub start_time: u64,
     pub timeout: u64,
     pub since: u32,
-    pub statistics: Bip9SoftforkStatistics,
+    pub statistics: Option<Bip9SoftforkStatistics>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
response from `getblockchaininfo` from Bitcoin core 0.19.1 on regtest contains the following
```json
"testdummy":{"active":true,"bip9":{"since":432,"start_time":0,"status":"active","timeout":9223372036854775807},"height":432,"type":"bip9"}}
```

which cause failure due to non-existing fields, this update struct `Bip9SoftforkInfo` to work