### PR TITLE
Update logging handling

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -9,10 +9,11 @@
 //
 
 use std::collections::HashMap;
+use std::fmt::{self, Write};
 use std::fs::File;
 use std::iter::FromIterator;
 use std::path::PathBuf;
-use std::{fmt, result};
+use std::result;
 
 use bitcoin;
 use jsonrpc;
@@ -22,7 +23,7 @@ use serde_json;
 use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::secp256k1::Signature;
 use bitcoin::{Address, Amount, Block, BlockHeader, OutPoint, PrivateKey, PublicKey, Script, Transaction};
-use log::Level::Debug;
+use log::Level::{Debug, Trace, Warn};
 use serde::{Deserialize, Serialize};
 
 use error::*;
@@ -986,15 +987,34 @@ impl RpcApi for Client {
     ) -> Result<T> {
         let req = self.client.build_request(&cmd, &args);
         if log_enabled!(Debug) {
-            debug!("JSON-RPC request: {}", serde_json::to_string(&req).unwrap());
+            debug!(target: "bitcoincore_rpc", "JSON-RPC request: {} {}", cmd, serde_json::Value::from(args));
         }
 
         let resp = self.client.send_request(&req).map_err(Error::from);
-        if log_enabled!(Debug) && resp.is_ok() {
-            let resp = resp.as_ref().unwrap();
-            debug!("JSON-RPC response: {}", serde_json::to_string(resp).unwrap());
-        }
+        log_response(cmd, &resp);
         Ok(resp?.into_result()?)
+    }
+}
+
+fn log_response(cmd: &str, resp: &Result<jsonrpc::Response>) {
+    if log_enabled!(Warn) || log_enabled!(Debug) || log_enabled!(Trace) {
+        match resp {
+            Err(ref e) => {
+                if log_enabled!(Debug) {
+                    debug!(target: "bitcoincore_rpc", "JSON-RPC failed parsing reply of {}: {:?}", cmd, e);
+                }
+            },
+            Ok(ref resp) => {
+                if let Some(ref e) = resp.error {
+                    if log_enabled!(Debug) {
+                        debug!(target: "bitcoincore_rpc", "JSON-RPC error for {}: {:?}", cmd, e);
+                    }
+                } else if log_enabled!(Trace) {
+                    let result = resp.result.as_ref().unwrap_or(&serde_json::Value::Null);
+                    trace!(target: "bitcoincore_rpc", "JSON-RPC response for {}: {}", cmd, result);
+                }
+            },
+        }
     }
 }
 


### PR DESCRIPTION
- Log failures to send the RPC request. Previously only valid json replies from the server with the `error` field (`RpcError`) were being logged.

- Promote error logging to `Warn`-level messages.

- Demote response logging to `Trace`-level messages.

- Log the requested method name in the response/error log message.

- More compact display for requests, with just the method and params instead of the whole json object. i.e. `getblockhash [176]` instead of `{"jsonrpc":"2.0","id":97,"method":"getblockhash","params":[176]}`

- More compact display for responses, with just the inner `result`. i.e. `7a9b99f78066f22a26c56b2035445285a5a992fc19719c9c27f2255f20f1f2f8` instead of `{"jsonrpc":"2.0","id":97,"error":null,"result":"7a9b99f78066f22a26c56b2035445285a5a992fc19719c9c27f2255f20f1f2f8"}`

I've found the logging to be more convenient with these changes in place while working on an app that uses rust-bitcoincore-rpc.
It's useful to see what requests are being sent and when, but seeing full json request and reply dumps for everything can be a bit too much.

Here's an example of how that looks like (with `pretty_env_logger`):

![image](https://user-images.githubusercontent.com/877904/81918037-a747cb80-95de-11ea-97c9-78198ae4965a.png)
