### PR TITLE
Add blockheight to wallet transaction responses

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -354,6 +354,7 @@ pub struct WalletTxInfo {
     pub blockhash: Option<bitcoin::BlockHash>,
     pub blockindex: Option<usize>,
     pub blocktime: Option<u64>,
+    pub blockheight: Option<u32>,
     pub txid: bitcoin::Txid,
     pub time: u64,
     pub timereceived: u64,


### PR DESCRIPTION
This field is newly added in 0.20

Fixes https://github.com/rust-bitcoin/rust-bitcoincore-rpc/issues/116.