### PR TITLE
Add scantxoutset

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use error::*;
 use json;
 use queryable;
+use serde_json::Value;
 
 /// Crate-specific Result type, shorthand for `std::result::Result` with our
 /// crate-specific Error type;
@@ -1014,8 +1015,11 @@ pub trait RpcApi: Sized {
         self.call("uptime", &[])
     }
 
-    fn scan_txout_set(&self, descriptors: &[String]) -> Result<json::ScanUtxoResult> {
-        self.call("scantxoutset", &["start".into(), descriptors.into()])
+    fn scan_txout_set_blocking(
+        &self,
+        descriptors: &[json::ScanTxoutRequest],
+    ) -> Result<json::ScanTxoutResult> {
+        self.call("scantxoutset", &["start".into(), into_json(descriptors)?])
     }
 }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1013,6 +1013,10 @@ pub trait RpcApi: Sized {
     fn uptime(&self) -> Result<u64> {
         self.call("uptime", &[])
     }
+
+    fn scan_txout_set(&self, descriptors: &[String]) -> Result<json::ScanUtxoResult> {
+        self.call("scantxoutset", &["start".into(), descriptors.into()])
+    }
 }
 
 /// Client implements a JSON-RPC client for the Bitcoin Core daemon or compatible APIs.

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1015,10 +1015,10 @@ pub trait RpcApi: Sized {
         self.call("uptime", &[])
     }
 
-    fn scan_txout_set_blocking(
+    fn scan_tx_out_set_blocking(
         &self,
-        descriptors: &[json::ScanTxoutRequest],
-    ) -> Result<json::ScanTxoutResult> {
+        descriptors: &[json::ScanTxOutRequest],
+    ) -> Result<json::ScanTxOutResult> {
         self.call("scantxoutset", &["start".into(), into_json(descriptors)?])
     }
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -30,7 +30,7 @@ use bitcoin::{
     Address, Amount, Network, OutPoint, PrivateKey, Script, SigHashType, SignedAmount, Transaction,
     TxIn, TxOut, Txid,
 };
-use bitcoincore_rpc::bitcoincore_rpc_json::ScanTxoutRequest;
+use bitcoincore_rpc::bitcoincore_rpc_json::ScanTxOutRequest;
 
 lazy_static! {
     static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
@@ -925,8 +925,9 @@ fn test_scantxoutset(cl: &Client) {
     cl.generate_to_address(2, &addr).unwrap();
     cl.generate_to_address(7, &cl.get_new_address(None, None).unwrap()).unwrap();
 
-    let utxos =
-        cl.scan_txout_set_blocking(&[ScanTxoutRequest::Single(format!("addr({})", addr))]).unwrap();
+    let utxos = cl
+        .scan_tx_out_set_blocking(&[ScanTxOutRequest::Single(format!("addr({})", addr))])
+        .unwrap();
 
     assert_eq!(utxos.unspents.len(), 2);
     assert_eq!(utxos.success, Some(true));

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -30,6 +30,7 @@ use bitcoin::{
     Address, Amount, Network, OutPoint, PrivateKey, Script, SigHashType, SignedAmount, Transaction,
     TxIn, TxOut, Txid,
 };
+use bitcoincore_rpc::bitcoincore_rpc_json::ScanTxoutRequest;
 
 lazy_static! {
     static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
@@ -138,6 +139,7 @@ fn main() {
     test_combine_psbt(&cl);
     test_finalize_psbt(&cl);
     test_list_received_by_address(&cl);
+    test_scantxoutset(&cl);
     test_import_public_key(&cl);
     test_import_priv_key(&cl);
     test_import_address(&cl);
@@ -915,6 +917,19 @@ fn test_get_network_hash_ps(cl: &Client) {
 
 fn test_uptime(cl: &Client) {
     cl.uptime().unwrap();
+}
+
+fn test_scantxoutset(cl: &Client) {
+    let addr = cl.get_new_address(None, None).unwrap();
+
+    cl.generate_to_address(2, &addr).unwrap();
+    cl.generate_to_address(7, &cl.get_new_address(None, None).unwrap()).unwrap();
+
+    let utxos =
+        cl.scan_txout_set_blocking(&[ScanTxoutRequest::Single(format!("addr({})", addr))]).unwrap();
+
+    assert_eq!(utxos.unspents.len(), 2);
+    assert_eq!(utxos.success, Some(true));
 }
 
 fn test_stop(cl: Client) {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1253,6 +1253,30 @@ pub enum PubKeyOrAddress<'a> {
     PubKey(&'a PublicKey),
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct ScanUtxoResult {
+    pub success: bool,
+    pub txouts: u64,
+    pub height: u64,
+    pub bestblock: bitcoin::BlockHash,
+    pub unspents: Vec<Utxo>,
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    pub total_amount: bitcoin::Amount,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Utxo {
+    pub txid: bitcoin::Txid,
+    pub vout: u32,
+    pub script_pub_key: bitcoin::Script,
+    #[serde(rename = "desc")]
+    pub descriptor: String,
+    #[serde(with = "bitcoin::util::amount::serde::as_btc")]
+    pub amount: bitcoin::Amount,
+    pub height: u64,
+}
+
 impl<'a> serde::Serialize for PubKeyOrAddress<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1256,7 +1256,7 @@ pub enum PubKeyOrAddress<'a> {
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(untagged)]
 /// Start a scan of the UTXO set for an [output descriptor](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).
-pub enum ScanTxoutRequest {
+pub enum ScanTxOutRequest {
     /// Scan for a single descriptor
     Single(String),
     /// Scan for a descriptor with xpubs
@@ -1269,7 +1269,7 @@ pub enum ScanTxoutRequest {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-pub struct ScanTxoutResult {
+pub struct ScanTxOutResult {
     pub success: Option<bool>,
     #[serde(rename = "txouts")]
     pub tx_outs: Option<u64>,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1254,11 +1254,28 @@ pub enum PubKeyOrAddress<'a> {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-pub struct ScanUtxoResult {
-    pub success: bool,
-    pub txouts: u64,
-    pub height: u64,
-    pub bestblock: bitcoin::BlockHash,
+#[serde(untagged)]
+/// Start a scan of the UTXO set for an [output descriptor](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).
+pub enum ScanTxoutRequest {
+    /// Scan for a single descriptor
+    Single(String),
+    /// Scan for a descriptor with xpubs
+    Extended {
+        /// Descriptor
+        desc: String,
+        /// Range of the xpub derivations to scan
+        range: (u64, u64),
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct ScanTxoutResult {
+    pub success: Option<bool>,
+    #[serde(rename = "txouts")]
+    pub tx_outs: Option<u64>,
+    pub height: Option<u64>,
+    #[serde(rename = "bestblock")]
+    pub best_block_hash: Option<bitcoin::BlockHash>,
     pub unspents: Vec<Utxo>,
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     pub total_amount: bitcoin::Amount,


### PR DESCRIPTION
Allows to query the bitcoin node's UTXO set for UTXOs belonging to descriptors.