### PR TITLE
Add explicit 'dyn' to Error::cause() result

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -94,7 +94,7 @@ impl error::Error for Error {
         "bitcoincore-rpc error"
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::JsonRpc(ref e) => Some(e),
             Error::Hex(ref e) => Some(e),


### PR DESCRIPTION
Otherwise, we get the following deprecation warning from latest Rust:
```
warning: trait objects without an explicit `dyn` are deprecated
  --> client/src/error.rs:97:32
   |
97 |     fn cause(&self) -> Option<&error::Error> {
   |                                ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`
   |
   = note: `#[warn(bare_trait_objects)]` on by default
```