### PR TITLE
Bump bitcoin dependency to 0.25

### DIFF
--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Steven Roose <steven@stevenroose.org>"]
 [dependencies]
 bitcoincore-rpc = { path = "../client" }
 lazy_static = "1.4.0"
-bitcoin = { version = "0.23", features = [ "use-serde", "rand" ] }
+bitcoin = { version = "0.25", features = [ "use-serde", "rand" ] }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -25,7 +25,6 @@ use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1;
-use bitcoin::util::hash::BitcoinHash;
 use bitcoin::{
     Address, Amount, Network, OutPoint, PrivateKey, Script, SigHashType, SignedAmount, Transaction,
     TxIn, TxOut, Txid,
@@ -193,7 +192,7 @@ fn test_get_new_address(cl: &Client) {
 fn test_dump_private_key(cl: &Client) {
     let addr = cl.get_new_address(None, Some(json::AddressType::Bech32)).unwrap();
     let sk = cl.dump_private_key(&addr).unwrap();
-    assert_eq!(addr, Address::p2wpkh(&sk.public_key(&SECP), *NET));
+    assert_eq!(addr, Address::p2wpkh(&sk.public_key(&SECP), *NET).unwrap());
 }
 
 fn test_generate(cl: &Client) {
@@ -258,7 +257,7 @@ fn test_get_block_header_get_block_header_info(cl: &Client) {
     let tip = cl.get_best_block_hash().unwrap();
     let header = cl.get_block_header(&tip).unwrap();
     let info = cl.get_block_header_info(&tip).unwrap();
-    assert_eq!(header.bitcoin_hash(), info.hash);
+    assert_eq!(header.block_hash(), info.hash);
     assert_eq!(header.version, info.version);
     assert_eq!(header.merkle_root, info.merkle_root);
     assert_eq!(info.confirmations, 1);
@@ -439,7 +438,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
         key: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
         compressed: true,
     };
-    let addr = Address::p2wpkh(&sk.public_key(&SECP), Network::Regtest);
+    let addr = Address::p2wpkh(&sk.public_key(&SECP), Network::Regtest).unwrap();
 
     let options = json::ListUnspentQueryOptions {
         minimum_amount: Some(btc(2)),

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 hex = "0.3"
 
-bitcoin = { version = "0.23", features = [ "use-serde" ] }
+bitcoin = { version = "0.25", features = [ "use-serde" ] }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -175,7 +175,7 @@ pub struct GetBlockResult {
     pub strippedsize: Option<usize>,
     pub weight: usize,
     pub height: usize,
-    pub version: u32,
+    pub version: i32,
     #[serde(default, with = "::serde_hex::opt")]
     pub version_hex: Option<Vec<u8>>,
     pub merkleroot: bitcoin::TxMerkleNode,
@@ -198,7 +198,7 @@ pub struct GetBlockHeaderResult {
     pub hash: bitcoin::BlockHash,
     pub confirmations: u32,
     pub height: usize,
-    pub version: u32,
+    pub version: i32,
     #[serde(default, with = "::serde_hex::opt")]
     pub version_hex: Option<Vec<u8>>,
     #[serde(rename = "merkleroot")]


### PR DESCRIPTION
Not sure about this crate versioning - should it be also bumped (to 0.12)?