### PR TITLE
Prepare release of v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 0.12.0
+- bump `bitcoin` dependency to version `0.25`, increasing our MSRV to `1.29.0`
+- test against `bitcoind` `0.20.0` and `0.20.1`
+- add `get_balances`
+- add `get_mempool_entry`
+- add `list_since_block`
+- add `get_mempool_entry`
+- add `list_since_block`
+- add `uptime`
+- add `get_network_hash_ps`
+- add `get_tx_out_set_info`
+- add `get_net_totals`
+- partially implement `scantxoutset`
+- extend `create_wallet` and related APIs
+- extend `GetWalletInfoResult`
+- extend `WalletTxInfo`
+- extend testsuite
+- fix `GetPeerInfoResult`
+- fix `GetNetworkInfoResult`
+- fix `GetTransactionResultDetailCategory`
+- fix `GetMempoolEntryResult` for bitcoind prior to `0.19.0`
+- fix `GetBlockResult` and `GetBlockHeaderResult`
 
 # 0.11.0
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ fn main() {
 
 See `client/examples/` for more usage examples. 
 
+# Supported Bitcoin Core Versions
+The following versions are officially supported and automatically tested:
+* 0.18.0
+* 0.18.1
+* 0.19.0.1
+* 0.19.1
+* 0.20.0
+* 0.20.1
 
 # Minimum Supported Rust Version (MSRV)
 This library should always compile with any combination of features on **Rust 1.29**.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
@@ -18,7 +18,7 @@ name = "bitcoincore_rpc"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoincore-rpc-json = { version = "0.11.0", path = "../json"}
+bitcoincore-rpc-json = { version = "0.12.0", path = "../json"}
 
 log = "0.4.5"
 jsonrpc = "0.11"

--- a/client/README.md
+++ b/client/README.md
@@ -9,9 +9,7 @@ in the interface of this crate.
 
 ## MSRV
 
-The MSRV for this crate used to be 1.24.0, but that has recently been broken
-by an external dependency. We have yet to decide on a new MSRV.
-
+please see the parent README for the current MSRV.
 
 # License
 

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc-json"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",


### PR DESCRIPTION
With the upgrade of `rust-bitcoin` to `0.25` this crate should upgrade too to be compatible.