### PR TITLE
Add 'submitblock' rpc call

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1155,6 +1155,27 @@ pub trait RpcApi: Sized {
         self.call("uptime", &[])
     }
 
+    /// Submit a block
+    fn submit_block(&self, block: &bitcoin::Block) -> Result<()> {
+        let block_hex: String = bitcoin::consensus::encode::serialize_hex(block);
+        self.submit_block_hex(&block_hex)
+    }
+
+    /// Submit a raw block
+    fn submit_block_bytes(&self, block_bytes: &[u8]) -> Result<()> {
+        let block_hex: String = block_bytes.to_hex();
+        self.submit_block_hex(&block_hex)
+    }
+
+    /// Submit a block as a hex string
+    fn submit_block_hex(&self, block_hex: &str) -> Result<()> {
+        match self.call("submitblock", &[into_json(&block_hex)?]) {
+            Ok(serde_json::Value::Null) => Ok(()),
+            Ok(res) => Err(Error::ReturnedError(res.to_string())),
+            Err(err) => Err(err.into()),
+        }
+    }
+
     fn scan_tx_out_set_blocking(
         &self,
         descriptors: &[json::ScanTxOutRequest],

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     InvalidCookieFile,
     /// The JSON result had an unexpected structure.
     UnexpectedStructure,
+    /// The daemon returned an error string.
+    ReturnedError(String),
 }
 
 impl From<jsonrpc::error::Error> for Error {
@@ -85,6 +87,7 @@ impl fmt::Display for Error {
             Error::InvalidAmount(ref e) => write!(f, "invalid amount: {}", e),
             Error::InvalidCookieFile => write!(f, "invalid cookie file"),
             Error::UnexpectedStructure => write!(f, "the JSON result had an unexpected structure"),
+            Error::ReturnedError(ref s) => write!(f, "the daemon returned an error string: {}", s),
         }
     }
 }


### PR DESCRIPTION
I added two methods to submit raw and hex-encoded blocks via RPC calls. 

Submitting blocks works, as tested in regtest mode. However, in case of success it currently yields the `Result`:

```
Err(JsonRpc(Json(Error("invalid type: null, expected a string", line: 0, column: 0))))
```

I think this happens because `submitblock` returns `null` in case of success (see [BIP022](https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki)). 

Any suggestions how I should handle that?