### PR TITLE
Compatibility with Bitcoin Core v0.21 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ jobs:
       env: BITCOINVERSION=0.20.0
     - rust: stable
       env: BITCOINVERSION=0.20.1
+    - rust: stable
+      env: BITCOINVERSION=0.21.0
 
 script:
   - ./contrib/test.sh

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -19,12 +19,12 @@ PID1=$!
 sleep 3
 
 BLOCKFILTERARG=""
-if bitcoind -version | grep -q "0\.19\|0\.20"; then
+if bitcoind -version | grep -q "v0\.\(19\|2\)"; then
     BLOCKFILTERARG="-blockfilterindex=1"
 fi
 
 FALLBACKFEEARG=""
-if bitcoind -version | grep -q "0\.20"; then
+if bitcoind -version | grep -q "v0\.2"; then
     FALLBACKFEEARG="-fallbackfee=0.00001000"
 fi
 

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -79,6 +79,17 @@ macro_rules! assert_not_found {
     };
 }
 
+/// Assert that the call returns the specified error message.
+macro_rules! assert_error_message {
+    ($call:expr, $code:expr, $msg:expr) => {
+        match $call.unwrap_err() {
+            Error::JsonRpc(JsonRpcError::Rpc(ref e))
+                if e.code == $code && e.message.contains($msg) => {}
+            e => panic!("expected '{}' error for {}, got: {}", $msg, stringify!($call), e),
+        }
+    };
+}
+
 static mut VERSION: usize = 0;
 /// Get the version of the node that is running.
 fn version() -> usize {
@@ -111,7 +122,7 @@ fn get_auth() -> bitcoincore_rpc::Auth {
 fn main() {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::max())).unwrap();
 
-    let rpc_url = get_rpc_url();
+    let rpc_url = format!("{}/wallet/testwallet", get_rpc_url());
     let auth = get_auth();
 
     let cl = Client::new(rpc_url, auth).unwrap();
@@ -119,6 +130,8 @@ fn main() {
     test_get_network_info(&cl);
     unsafe { VERSION = cl.version().unwrap() };
     println!("Version: {}", version());
+
+    cl.create_wallet("testwallet", None, None, None, None).unwrap();
 
     test_get_mining_info(&cl);
     test_get_blockchain_info(&cl);
@@ -226,8 +239,12 @@ fn test_generate(cl: &Client) {
         assert_eq!(blocks.len(), 6);
     } else if version() < 190000 {
         assert_deprecated!(cl.generate(5, None));
-    } else {
+    } else if version() < 210000 {
         assert_not_found!(cl.generate(5, None));
+    } else {
+        // Bitcoin Core v0.21 appears to return this with a generic -1 error code,
+        // rather than the expected -32601 code (RPC_METHOD_NOT_FOUND).
+        assert_error_message!(cl.generate(5, None), -1, "replaced by the -generate cli option");
     }
 }
 
@@ -586,6 +603,7 @@ fn test_fund_raw_transaction(cl: &Client) {
     output.insert(RANDOM_ADDRESS.to_string(), btc(1));
 
     let options = json::FundRawTransactionOptions {
+        add_inputs: None,
         change_address: Some(addr),
         change_position: Some(0),
         change_type: None,
@@ -602,6 +620,7 @@ fn test_fund_raw_transaction(cl: &Client) {
     let _ = funded.transaction().unwrap();
 
     let options = json::FundRawTransactionOptions {
+        add_inputs: None,
         change_address: None,
         change_position: Some(0),
         change_type: Some(json::AddressType::Legacy),
@@ -663,6 +682,7 @@ fn test_wallet_create_funded_psbt(cl: &Client) {
     output.insert(RANDOM_ADDRESS.to_string(), btc(1));
 
     let options = json::WalletCreateFundedPsbtOptions {
+        add_inputs: None,
         change_address: None,
         change_position: Some(1),
         change_type: Some(json::AddressType::Legacy),
@@ -685,6 +705,7 @@ fn test_wallet_create_funded_psbt(cl: &Client) {
         .unwrap();
 
     let options = json::WalletCreateFundedPsbtOptions {
+        add_inputs: None,
         change_address: Some(addr),
         change_position: Some(1),
         change_type: None,
@@ -939,8 +960,9 @@ fn test_create_wallet(cl: &Client) {
 
     wallet_list.sort();
 
-    // Default wallet
-    assert_eq!(wallet_list.remove(0), "");
+    // Main wallet created for tests
+    assert!(wallet_list.iter().any(|w| w == "testwallet"));
+    wallet_list.retain(|w| w != "testwallet" && w != "");
 
     // Created wallets
     assert!(wallet_list.iter().zip(wallet_names).all(|(a, b)| a == b));


### PR DESCRIPTION
As per the changes described in https://bitcoincore.org/en/releases/0.21.0.

v0.21 no longer creates a wallet by default, so we have to create one. I changed the tests to always create a new `testwallet` wallet, let me know if you prefer to only do this for v0.21+.