### PR TITLE
add: support for getblocktemplate in template mode

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -351,6 +351,29 @@ pub trait RpcApi: Sized {
         self.call("getmininginfo", &[])
     }
 
+    fn get_block_template(
+        &self,
+        mode: json::GetBlockTemplateModes,
+        rules: &[json::GetBlockTemplateRules],
+        capabilities: &[json::GetBlockTemplateCapabilities],
+    ) -> Result<json::GetBlockTemplateResult> {
+        #[derive(Serialize)]
+        struct Argument<'a> {
+            mode: json::GetBlockTemplateModes,
+            rules: &'a [json::GetBlockTemplateRules],
+            capabilities: &'a [json::GetBlockTemplateCapabilities],
+        }
+
+        self.call(
+            "getblocktemplate",
+            &[into_json(Argument {
+                mode: mode,
+                rules: rules,
+                capabilities: capabilities,
+            })?],
+        )
+    }
+
     /// Returns a data structure containing various state info regarding
     /// blockchain processing.
     fn get_blockchain_info(&self) -> Result<json::GetBlockchainInfoResult> {


### PR DESCRIPTION
Partly addresses https://github.com/rust-bitcoin/rust-bitcoincore-rpc/issues/133

This adds basic support for the `getblocktemplate` RCP to the client. The default 'template' mode, in which Bitcoin Core builds and returns a block template to the RPC client, is implemented. The 'proposal' mode, where the client submits a block to Bitcoin Core for validation (before it's mined; proof-of-work is not checked) as well as longpolling  for changes to a given block template are not implemented yet. However, the basic implementation proposed here can be extended to support both of these features without changing the API.

I've focused on the subset of features (also called "capabilities") that Bitcoin Core actually implements from BIP 22 and BIP 23. I've tested this against mainnet, testnet, regtest and signet with the Rust code provided below. 

Reviewers might find the following resources useful:

- [getblocktemplate()](https://github.com/bitcoin/bitcoin/blob/e9c037ba64dd5b073fccf059ef75db1c97abd0bd/src/rpc/mining.cpp#L505) in [bitcoin/bitcoin/src/rpc/mining.cpp @ master](https://github.com/bitcoin/bitcoin/blob/master/src/rpc/mining.cpp)
- [BIP-22: getblocktemplate - Fundamentals](https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki): Non Optional Sections
- [BIP-23: getblocktemplate - Pooled Mining](https://github.com/bitcoin/bips/blob/master/bip-0023.mediawiki): Mutations

<details>
  <summary>Code for playing around with this</summary>

```Rust
use bitcoincore_rpc::json::{GetBlockTemplateOptionsModes, GetBlockTemplateOptionsRules};
use bitcoincore_rpc::{Auth, Client, RpcApi};

fn main() {
    // mainnet rpc port: 8332
    // testnet rpc port: 18332
    // regtest rpc port: 18444
    // signet rpc port: 38332
    let rpc = Client::new(
        "http://127.0.0.1:8332".to_string(),
        Auth::UserPass("your user".to_string(), "your pass".to_string()),
    )
    .unwrap();

    let get_block_template = rpc
        .get_block_template(
            GetBlockTemplateOptionsModes::Template,
            vec![
                GetBlockTemplateOptionsRules::SegWit,
                // GetBlockTemplateOptionsRules::Signet, for signet
            ],
            vec![],
        )
        .unwrap();

    println!("template: {:#?}", get_block_template);
}
```
</details>
