### PR TITLE
add: support for getchaintips

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -849,6 +849,12 @@ pub trait RpcApi: Sized {
         self.call("getmempoolentry", &[into_json(txid)?])
     }
 
+    /// Get information about all known tips in the block tree, including the
+    /// main chain as well as stale branches.
+    fn get_chain_tips(&self) -> Result<json::GetChainTipsResult> {
+        self.call("getchaintips", &[])
+    }
+
     fn send_to_address(
         &self,
         address: &Address,

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -184,6 +184,7 @@ fn main() {
     test_rescan_blockchain(&cl);
     test_create_wallet(&cl);
     test_get_tx_out_set_info(&cl);
+    test_get_chain_tips(&cl);
     test_get_net_totals(&cl);
     test_get_network_hash_ps(&cl);
     test_uptime(&cl);
@@ -996,6 +997,11 @@ fn test_create_wallet(cl: &Client) {
 
 fn test_get_tx_out_set_info(cl: &Client) {
     cl.get_tx_out_set_info().unwrap();
+}
+
+fn test_get_chain_tips(cl: &Client) {
+    let tips = cl.get_chain_tips().unwrap();
+    assert_eq!(tips.len(), 1);
 }
 
 fn test_get_net_totals(cl: &Client) {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1182,6 +1182,41 @@ pub struct FinalizePsbtResult {
     pub complete: bool,
 }
 
+/// Models the result of "getchaintips"
+pub type GetChainTipsResult = Vec<GetChainTipsResultTip>;
+
+/// Models a single chain tip for the result of "getchaintips"
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct GetChainTipsResultTip {
+    /// Block height of the chain tip
+    pub height: u64,
+    /// Header hash of the chain tip
+    pub hash: bitcoin::BlockHash,
+    /// Length of the branch (number of blocks since the last common block)
+    #[serde(rename = "branchlen")]
+    pub branch_length: usize,
+    /// Status of the tip as seen by Bitcoin Core
+    pub status: GetChainTipsResultStatus,
+}
+
+#[derive(Copy, Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum GetChainTipsResultStatus {
+    /// The branch contains at least one invalid block
+    Invalid,
+    /// Not all blocks for this branch are available, but the headers are valid
+    #[serde(rename = "headers-only")]
+    HeadersOnly,
+    /// All blocks are available for this branch, but they were never fully validated
+    #[serde(rename = "valid-headers")]
+    ValidHeaders,
+    /// This branch is not part of the active chain, but is fully validated
+    #[serde(rename = "valid-fork")]
+    ValidFork,
+    /// This is the tip of the active main chain, which is certainly valid
+    Active,
+}
+
 impl FinalizePsbtResult {
     pub fn transaction(&self) -> Option<Result<Transaction, encode::Error>> {
         self.hex.as_ref().map(|h| encode::deserialize(h))


### PR DESCRIPTION
This adds support for the [getchaintips](https://developer.bitcoin.org/reference/rpc/getchaintips.html) RPC returing a list of tips from the blocktree.

Code I used to play around with this:

```Rust
use bitcoincore_rpc::{Auth, Client, RpcApi};

fn main() {
    // mainnet rpc port: 8332
    // testnet rpc port: 18332
    // regtest rpc port: 18444
    // signet rpc port: 38332
    let rpc = Client::new(
        "http://127.0.0.1:8332".to_string(),
        Auth::UserPass("your user".to_string(), "your pass".to_string()),
    )
    .unwrap();

    println!("chain tip: {:#?}", rpc.get_chain_tips());
}
```