### PR TITLE
Limit the log dep version to keep MSRV

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 [dependencies]
 bitcoincore-rpc-json = { version = "0.13.0", path = "../json"}
 
-log = "0.4.5"
+log = ">=0.4.5, <0.4.14"
 jsonrpc = "0.11"
 
 # Used for deserialization of JSON.


### PR DESCRIPTION
This should fix the MSRV build in CI.