### PR TITLE
fix: vbavailable map in GetBlockTemplateResult

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1195,7 +1195,7 @@ pub struct GetBlockTemplateResult {
     pub capabilities: Vec<GetBlockTemplateResultCapabilities>,
     /// Set of pending, supported versionbit (BIP 9) softfork deployments
     #[serde(rename = "vbavailable")]
-    pub version_bits_available: HashMap<u32, String>,
+    pub version_bits_available: HashMap<String, u32>,
     /// Bit mask of versionbits the server requires set in submissions
     #[serde(rename = "vbrequired")]
     pub version_bits_required: u32,


### PR DESCRIPTION
PR #163 implemented support for `getblocktemplate`. However, during the implementation the `version_bits_available` HashMap the map fields were switched.

This became apparent during testing against a v0.21.1 Bitcoin Core node, which includes support for the Taproot softfork via the 2nd version bit. Previously, no softfork was defined.

```
$ bitcoin-cli getblocktemplate "{\"rules\": [\"segwit\"]}"
...
  "vbavailable": {
    "taproot": 2
  },
...
```