### PR TITLE
add new method list_wallet_dir

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -294,6 +294,10 @@ pub trait RpcApi: Sized {
         self.call("listwallets", &[])
     }
 
+    fn list_wallet_dir(&self) -> Result<json::ListWalletDirResult> {
+        self.call("listwalletdir", &[])
+    }
+
     fn get_wallet_info(&self) -> Result<json::GetWalletInfoResult> {
         self.call("getwalletinfo", &[])
     }

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -5,9 +5,6 @@ TESTDIR=/tmp/rust_bitcoincore_rpc_test
 rm -rf ${TESTDIR}
 mkdir -p ${TESTDIR}/1 ${TESTDIR}/2
 
-# To kill any remaining open bitcoind.
-killall -9 bitcoind
-
 bitcoind -regtest \
     -datadir=${TESTDIR}/1 \
     -port=12348 \

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -16,7 +16,7 @@ extern crate bitcoincore_rpc;
 extern crate lazy_static;
 extern crate log;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use bitcoincore_rpc::json;
 use bitcoincore_rpc::jsonrpc::error::Error as JsonRpcError;
@@ -948,7 +948,7 @@ fn test_create_wallet(cl: &Client) {
         });
     }
 
-    for wallet_param in wallet_params {
+    for wallet_param in wallet_params.iter() {
         let result = cl
             .create_wallet(
                 wallet_param.name,
@@ -995,7 +995,12 @@ fn test_create_wallet(cl: &Client) {
     wallet_list.retain(|w| w != "testwallet" && w != "");
 
     // Created wallets
-    assert!(wallet_list.iter().zip(wallet_names).all(|(a, b)| a == b));
+    assert!(wallet_list.iter().zip(&wallet_names).all(|(a, b)| a == *b));
+
+    let wallet_dir_list: HashSet<_> =
+        cl.list_wallet_dir().unwrap().wallets.into_iter().map(|n| n.name).collect();
+
+    assert!(wallet_params.iter().all(|p| wallet_dir_list.contains(p.name)));
 }
 
 fn test_get_tx_out_set_info(cl: &Client) {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -161,6 +161,16 @@ pub struct GetWalletInfoResult {
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct ListWalletDirResult {
+    pub wallets: Vec<WalletName>,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct WalletName {
+    pub name: String,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ScanningDetails {
     Scanning {
@@ -835,7 +845,7 @@ impl<'a> serde::Serialize for ImportMultiRequestScriptPubkey<'a> {
                 #[derive(Serialize)]
                 struct Tmp<'a> {
                     pub address: &'a Address,
-                };
+                }
                 serde::Serialize::serialize(
                     &Tmp {
                         address: addr,


### PR DESCRIPTION
Also 8bb030d89e1d1466f70e4dca67b611833026dc6c disable the killall because it could badly interact with the dev environment, in optimal case is not necessary anyway since bitcoind process are killed at the end of the bash script

Side note: without `list_wallet_dir` I can't think of a working solution to the problem of a client trying to:
* check if a wallet `x` is loaded (list_wallets)
  * if not, should i call `load_wallet` (because it already exist) or `create_wallet` (because it doesn't exist)?
Note that a strategy, try to load and act on error is not optimal because you should match on error string returned
Did anybody solve this in another way?