### PR TITLE
updates to newer jsonrpc dependencies containing swappable transports

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,4 +25,4 @@ jsonrpc = "0.12.0"
 
 # Used for deserialization of JSON.
 serde = "1"
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json = "1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.13.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
-    "Dawid Ciężarkiewicz <dpc@dpc.pw>"
+    "Dawid Ciężarkiewicz <dpc@dpc.pw>",
 ]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
 repository = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
 description = "RPC client library for the Bitcoin Core JSON-RPC API."
-keywords = [ "crypto", "bitcoin", "bitcoin-core", "rpc" ]
+keywords = ["crypto", "bitcoin", "bitcoin-core", "rpc"]
 readme = "README.md"
 
 [lib]
@@ -18,11 +18,11 @@ name = "bitcoincore_rpc"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoincore-rpc-json = { version = "0.13.0", path = "../json"}
+bitcoincore-rpc-json = { version = "0.13.0", path = "../json" }
 
 log = "0.4.5"
-jsonrpc = "0.11"
+jsonrpc = "0.12.0"
 
 # Used for deserialization of JSON.
 serde = "1"
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }

--- a/client/examples/test_against_node.rs
+++ b/client/examples/test_against_node.rs
@@ -23,7 +23,7 @@ fn main_result() -> Result<(), Error> {
     let user = args.next().expect("no user given");
     let pass = args.next().expect("no pass given");
 
-    let rpc = Client::new(url, Auth::UserPass(user, pass)).unwrap();
+    let rpc = Client::new(&url, Auth::UserPass(user, pass)).unwrap();
 
     let _blockchain_info = rpc.get_blockchain_info()?;
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -12,18 +12,13 @@ echo "PATH: \"$PATH\""
 if [ "$TRAVIS_RUST_VERSION" = "1.29.0" ]; then
     cargo generate-lockfile --verbose
 
-    # hyper depends on log 0.3 while we depnd on 0.4, so cargo doesn't know which one to pin
-    LOG_4_PATCH="$(cargo update --package "log" --precise "0.4.13" 2>&1 | sed -n "s/.*log:0.4.\([0-9]*\)/\1/p")"
-    cargo update --package "log:0.4.$LOG_4_PATCH" --precise "0.4.13"
-
+    cargo update --verbose --package "log" --precise "0.4.13"
     cargo update --verbose --package "cc" --precise "1.0.41"
     cargo update --verbose --package "cfg-if" --precise "0.1.9"
-    cargo update --verbose --package "unicode-normalization" --precise "0.1.9"
     cargo update --verbose --package "serde_json" --precise "1.0.39"
     cargo update --verbose --package "serde" --precise "1.0.98"
     cargo update --verbose --package "serde_derive" --precise "1.0.98"
     cargo update --verbose --package "byteorder" --precise "1.3.4"
-    cargo update --verbose --package "unicode-bidi" --precise "0.3.4"
 fi
 
 if [ -n "$RUSTFMTCHECK" ]; then

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -127,7 +127,7 @@ fn main() {
     let rpc_url = format!("{}/wallet/testwallet", get_rpc_url());
     let auth = get_auth();
 
-    let cl = Client::new(rpc_url, auth).unwrap();
+    let cl = Client::new(&rpc_url, auth).unwrap();
 
     test_get_network_info(&cl);
     unsafe { VERSION = cl.version().unwrap() };
@@ -969,7 +969,7 @@ fn test_create_wallet(cl: &Client) {
         assert_eq!(result.warning, expected_warning);
 
         let wallet_client_url = format!("{}{}{}", get_rpc_url(), "/wallet/", wallet_param.name);
-        let wallet_client = Client::new(wallet_client_url, get_auth()).unwrap();
+        let wallet_client = Client::new(&wallet_client_url, get_auth()).unwrap();
         let wallet_info = wallet_client.get_wallet_info().unwrap();
 
         assert_eq!(wallet_info.wallet_name, wallet_param.name);


### PR DESCRIPTION
This is similar to https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/154 but it seems that has stalled. I fixed the "temporary hack" found in #154 as well.

I ran the integration tests against regtest and everything seems to work. Seems like we should get this in so that we can create a tor transport.

My question separately from this PR is where should the work for adding tor transports go? Should it be part of the actual jsonrpc library? Should it be part of this package? or should it be its own package entirely?