### PR TITLE
Proof of Concept: Make tests independent using bitcoind crate and migrate to github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Test
+
+on: [push]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, macos-10.15 ]
+        feature: [ "bitcoind/0_21_1", "bitcoind/0_21_0", "bitcoind/0_20_1", "bitcoind/0_20_0", "bitcoind/0_19_1", "bitcoind/0_19_0_1", "bitcoind/0_18_1", "bitcoind/0_18_0", "bitcoind/0_17_1"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/
+            target
+          key: ${{ matrix.os }}-${{ matrix.feature }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features ${{ matrix.feature }}
+
+  cosmetics:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          components: rustfmt, clippy
+      - name: fmt
+        run: cargo fmt -- --check
+      - name: clippy
+        run: cargo clippy -- -D warnings

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,3 +26,6 @@ jsonrpc = "0.11"
 # Used for deserialization of JSON.
 serde = "1"
 serde_json = "1"
+
+[dev-dependencies]
+bitcoind = "0.12"

--- a/client/tests/integration.rs
+++ b/client/tests/integration.rs
@@ -1,0 +1,24 @@
+extern crate bitcoincore_rpc;
+extern crate bitcoind;
+
+use bitcoincore_rpc::{Auth, Client, RpcApi};
+use bitcoind::{downloaded_exe_path, BitcoinD};
+
+fn init() -> (Client, BitcoinD) {
+    let exe = std::env::var("BITCOIND_EXE")
+        .ok()
+        .or(downloaded_exe_path())
+        .expect("BITCOIND_EXE or bitcoind version feature must be specified");
+    let bitcoind = bitcoind::BitcoinD::new(exe).unwrap();
+    let auth = Auth::CookieFile(bitcoind.params.cookie_file.clone());
+    let cl = Client::new(bitcoind.rpc_url(), auth).unwrap();
+
+    (cl, bitcoind)
+}
+
+#[test]
+fn test_get_blockchain_info() {
+    let (cl, _bitcoind) = init();
+    let info = cl.get_blockchain_info().unwrap();
+    assert_eq!(&info.chain, "regtest");
+}


### PR DESCRIPTION
I think we should migrate to github actions and make integrations tests independent proper `#[test]` like I have done here with `test_get_blockchain_info`

Since it's a big refactor, I would like feedback and non-binding pre-approval before continuing