### PR TITLE
Support 'witness_v1_taproot' in ScriptPubkeyType enum

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -628,6 +628,7 @@ pub enum ScriptPubkeyType {
     NullData,
     Witness_v0_KeyHash,
     Witness_v0_ScriptHash,
+    Witness_v1_Taproot,
     Witness_Unknown,
 }
 


### PR DESCRIPTION
Should fix https://github.com/romanz/electrs/issues/427.