### PR TITLE
Adds `generate_block` function to `Client`

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -846,6 +846,16 @@ pub trait RpcApi: Sized {
         self.call("generatetoaddress", &[block_num.into(), address.to_string().into()])
     }
 
+    /// Mine a block with a set of ordered transactions immediately to a specified
+    /// address or descriptor (before the RPC call returns)
+    fn generate_block(
+        &self,
+        output: &Address,
+        transactions: &[bitcoin::Txid],
+    ) -> Result<json::GenerateBlockResult> {
+        self.call("generateblock", &[into_json(output)?, into_json(transactions)?])
+    }
+
     /// Mine up to block_num blocks immediately (before the RPC call returns)
     /// to an address in the wallet.
     fn generate(&self, block_num: u64, maxtries: Option<u64>) -> Result<Vec<bitcoin::BlockHash>> {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1657,6 +1657,12 @@ pub struct Utxo {
     pub height: u64,
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerateBlockResult {
+    hash: bitcoin::BlockHash,
+}
+
 impl<'a> serde::Serialize for PubKeyOrAddress<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
This PR adds a `generate_block` function to `Client` type according to the reference page https://developer.bitcoin.org/reference/rpc/generateblock.html.