### PR TITLE
Make 'threshold' and 'possible' BIP9 statistics optional

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -582,10 +582,10 @@ pub enum Bip9SoftforkStatus {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct Bip9SoftforkStatistics {
     pub period: u32,
-    pub threshold: u32,
+    pub threshold: Option<u32>,
     pub elapsed: u32,
     pub count: u32,
-    pub possible: bool,
+    pub possible: Option<bool>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Following https://github.com/bitcoin/bitcoin/pull/21934, latest Bitcoin Core `getblockchaininfo` RPC does not return the `threshold` and `possible` keys after a softwork is locked in:
```
$ bitcoin-cli getblockchaininfo | jq .softforks.taproot
{
  "type": "bip9",
  "bip9": {
    "status": "locked_in",
    "bit": 2,
    "start_time": 1619222400,
    "timeout": 1628640000,
    "since": 687456,
    "statistics": {
      "period": 2016,
      "elapsed": 1721,
      "count": 1718
    },
    "min_activation_height": 709632
  },
  "active": false
}
```