### PR TITLE
Adding `importdescriptors` for Descriptor-Based Wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+** This is a fork of https://github.com/rust-bitcoin/rust-bitcoincore-rpc with bitcoin 0.27 **
+
 [![Status](https://travis-ci.org/rust-bitcoin/rust-bitcoincore-rpc.png?branch=master)](https://travis-ci.org/rust-bitcoin/rust-bitcoincore-rpc)
 
 # Rust RPC client for Bitcoin Core JSON-RPC 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,24 +1,25 @@
 [package]
-name = "bitcoincore-rpc"
-version = "0.13.0"
+name = "core-rpc"
+version = "0.14.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
     "Dawid Ciężarkiewicz <dpc@dpc.pw>",
+    "Riccardo Casatta <riccardo@casatta.it>",
 ]
 license = "CC0-1.0"
-homepage = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
-repository = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
+homepage = "https://github.com/RCasatta/rust-bitcoincore-rpc/"
+repository = "https://github.com/RCasatta/rust-bitcoincore-rpc/"
 description = "RPC client library for the Bitcoin Core JSON-RPC API."
 keywords = ["crypto", "bitcoin", "bitcoin-core", "rpc"]
 readme = "README.md"
 
 [lib]
-name = "bitcoincore_rpc"
+name = "core_rpc"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoincore-rpc-json = { version = "0.13.0", path = "../json" }
+core-rpc-json = { version = "0.14.0", path = "../json" }
 
 log = "0.4.5"
 jsonrpc = "0.12.0"

--- a/client/examples/retry_client.rs
+++ b/client/examples/retry_client.rs
@@ -8,7 +8,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-extern crate bitcoincore_rpc;
+extern crate core_rpc as bitcoincore_rpc;
 extern crate jsonrpc;
 extern crate serde;
 extern crate serde_json;

--- a/client/examples/test_against_node.rs
+++ b/client/examples/test_against_node.rs
@@ -10,7 +10,7 @@
 
 //! A very simple example used as a self-test of this library against a Bitcoin
 //! Core node.
-extern crate bitcoincore_rpc;
+extern crate core_rpc as bitcoincore_rpc;
 
 use bitcoincore_rpc::{bitcoin, Auth, Client, Error, RpcApi};
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -13,7 +13,7 @@
 //! This is a client library for the Bitcoin Core JSON-RPC API.
 //!
 
-#![crate_name = "bitcoincore_rpc"]
+#![crate_name = "core_rpc"]
 #![crate_type = "rlib"]
 
 #[macro_use]
@@ -25,8 +25,8 @@ extern crate serde_json;
 
 pub extern crate jsonrpc;
 
-pub extern crate bitcoincore_rpc_json;
-pub use bitcoincore_rpc_json as json;
+pub extern crate core_rpc_json;
+pub use core_rpc_json as json;
 pub use json::bitcoin;
 
 mod client;

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Steven Roose <steven@stevenroose.org>"]
 
 [dependencies]
-bitcoincore-rpc = { path = "../client" }
-bitcoin = { version = "0.26", features = [ "use-serde", "rand" ] }
+core-rpc = { path = "../client" }
+bitcoin = { version = "0.27", features = [ "use-serde", "rand" ] }
 lazy_static = "1.4.0"
 log = "0.4"

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -19,12 +19,12 @@ PID1=$!
 sleep 3
 
 BLOCKFILTERARG=""
-if bitcoind -version | grep -q "v0\.\(19\|2\)"; then
+if bitcoind -version | grep -q "v\(0\.19\|0\.2\|2\)"; then
     BLOCKFILTERARG="-blockfilterindex=1"
 fi
 
 FALLBACKFEEARG=""
-if bitcoind -version | grep -q "v0\.2"; then
+if bitcoind -version | grep -q "v\(0\.2\|2\)"; then
     FALLBACKFEEARG="-fallbackfee=0.00001000"
 fi
 

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -11,10 +11,12 @@
 #![deny(unused)]
 
 extern crate bitcoin;
-extern crate bitcoincore_rpc;
+extern crate core_rpc as bitcoincore_rpc;
 #[macro_use]
 extern crate lazy_static;
 extern crate log;
+
+use bitcoincore_rpc::core_rpc_json as bitcoincore_rpc_json;
 
 use std::collections::HashMap;
 
@@ -30,7 +32,7 @@ use bitcoin::{
     Address, Amount, Network, OutPoint, PrivateKey, Script, SigHashType, SignedAmount, Transaction,
     TxIn, TxOut, Txid,
 };
-use bitcoincore_rpc::bitcoincore_rpc_json::{
+use bitcoincore_rpc_json::{
     GetBlockTemplateModes, GetBlockTemplateRules, ScanTxOutRequest,
 };
 

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,24 +1,25 @@
 [package]
-name = "bitcoincore-rpc-json"
-version = "0.13.0"
+name = "core-rpc-json"
+version = "0.14.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
-    "Dawid Ciężarkiewicz <dpc@dpc.pw>"
+    "Dawid Ciężarkiewicz <dpc@dpc.pw>",
+    "Riccardo Casatta <riccardo@casatta.it>",
 ]
 license = "CC0-1.0"
-homepage = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
-repository = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
+homepage = "https://github.com/RCasatta/rust-bitcoincore-rpc/"
+repository = "https://github.com/RCasatta/rust-bitcoincore-rpc/"
 description = "JSON-enabled type structs for bitcoincore-rpc crate."
 keywords = [ "crypto", "bitcoin", "bitcoin-core", "rpc" ]
 readme = "README.md"
 
 [lib]
-name = "bitcoincore_rpc_json"
+name = "core_rpc_json"
 path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 
-bitcoin = { version = "0.26", features = [ "use-serde" ] }
+bitcoin = { version = "0.27", features = [ "use-serde" ] }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -13,7 +13,7 @@
 //! This is a client library for the Bitcoin Core JSON-RPC API.
 //!
 
-#![crate_name = "bitcoincore_rpc_json"]
+#![crate_name = "core_rpc_json"]
 #![crate_type = "rlib"]
 
 pub extern crate bitcoin;
@@ -835,7 +835,7 @@ impl<'a> serde::Serialize for ImportMultiRequestScriptPubkey<'a> {
                 #[derive(Serialize)]
                 struct Tmp<'a> {
                     pub address: &'a Address,
-                };
+                }
                 serde::Serialize::serialize(
                     &Tmp {
                         address: addr,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1066,11 +1066,13 @@ pub struct GetPeerInfoResult {
 }
 
 #[derive(Copy, Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum GetPeerInfoResultNetwork {
     Ipv4,
     Ipv6,
     Onion,
+    I2p,
+    NotPubliclyRoutable,
     // this is undocumented upstream
     Unroutable,
 }
@@ -1607,6 +1609,7 @@ pub enum AddressType {
     Legacy,
     P2shSegwit,
     Bech32,
+    Bech32m,
 }
 
 /// Used to represent arguments that can either be an address or a public key.
@@ -1685,4 +1688,24 @@ where
         res.push(FromHex::from_hex(&h).map_err(D::Error::custom)?);
     }
     Ok(Some(res))
+}
+
+/// Import Descriptor Request
+#[derive(Serialize, Clone, PartialEq, Eq, Debug)]
+pub struct ImportDescriptorRequest {
+    pub active: bool,
+    #[serde(rename = "desc")]
+    pub descriptor: String,
+    pub range: [i64; 2],
+    pub next_index: i64,
+    pub timestamp: String,
+    pub internal: bool,
+}
+
+/// Imported Descriptor Result
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct ImportDescriptorResult {
+    pub success: bool,
+    pub warnings: Option<Vec<String>>,
+    pub error: Option<String>,
 }


### PR DESCRIPTION
This PR adds the following features:
1. `importdescriptors` RPC command
2. `Bech32m` address support
3. Updated `createwallet` to add in `descriptors` parameter

The `integration_test/run.sh` script was updated to support the latest versioning of Bitcoin Core.

I figure this would be very useful for anyone creating descriptor based wallets, especially with Taproot coming in!