### PR TITLE
Add new network variants to GetPeerInfoResultNetwork

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -998,7 +998,7 @@ pub struct GetPeerInfoResult {
     /// Local address as reported by the peer
     // TODO: use a type for addrlocal
     pub addrlocal: Option<String>,
-    /// Network (ipv4, ipv6, or onion) the peer connected throug
+    /// Network (ipv4, ipv6, or onion) the peer connected through
     /// Added in Bitcoin Core v0.21
     pub network: Option<GetPeerInfoResultNetwork>,
     /// The services offered
@@ -1066,13 +1066,17 @@ pub struct GetPeerInfoResult {
 }
 
 #[derive(Copy, Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum GetPeerInfoResultNetwork {
     Ipv4,
     Ipv6,
     Onion,
-    // this is undocumented upstream
+    #[deprecated]
     Unroutable,
+    NotPubliclyRoutable,
+    I2p,
+    Cjdns,
+    Internal,
 }
 
 #[derive(Copy, Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]


### PR DESCRIPTION
Added missing network type variants that are found in `bitcoin/src/netbase.cpp` up to version `0.22`. 