### PR TITLE
Update GetPeerInfoResultNetwork for core 22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
       env: BITCOINVERSION=0.20.1
     - rust: stable
       env: BITCOINVERSION=0.21.0
+    - rust: stable
+      env: BITCOINVERSION=22.0
 
 script:
   - ./contrib/test.sh

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following versions are officially supported and automatically tested:
 * 0.20.0
 * 0.20.1
 * 0.21.0
+* 22.0
 
 # Minimum Supported Rust Version (MSRV)
 This library should always compile with any combination of features on **Rust 1.29**.

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -19,12 +19,12 @@ PID1=$!
 sleep 3
 
 BLOCKFILTERARG=""
-if bitcoind -version | grep -q "v0\.\(19\|2\)"; then
+if bitcoind -version | grep -q "v\(0\.19\|0\.2\|2\)"; then
     BLOCKFILTERARG="-blockfilterindex=1"
 fi
 
 FALLBACKFEEARG=""
-if bitcoind -version | grep -q "v0\.2"; then
+if bitcoind -version | grep -q "v\(0\.2\|2\)"; then
     FALLBACKFEEARG="-fallbackfee=0.00001000"
 fi
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1066,11 +1066,13 @@ pub struct GetPeerInfoResult {
 }
 
 #[derive(Copy, Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum GetPeerInfoResultNetwork {
     Ipv4,
     Ipv6,
     Onion,
+    I2p,
+    NotPubliclyRoutable,
     // this is undocumented upstream
     Unroutable,
 }


### PR DESCRIPTION
This PR extracts the changes to support Bitcoin Core 22.0 testing from #199. 

1. add I2p and NotPubliclyRoutable to json::GetPeerInfoResultNetwork
2. update integration_test/run.sh to support versions beginning with 2
3. update .travis.yml to run integration tests with Bitcoin Core 22.0