### PR TITLE
Make pub_keypool_oldest optional

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -146,7 +146,7 @@ pub struct GetWalletInfoResult {
     #[serde(rename = "txcount")]
     pub tx_count: usize,
     #[serde(rename = "keypoololdest")]
-    pub keypool_oldest: usize,
+    pub keypool_oldest: Option<usize>,
     #[serde(rename = "keypoolsize")]
     pub keypool_size: usize,
     #[serde(rename = "keypoolsize_hd_internal")]


### PR DESCRIPTION
* Issue
Currently, get_wallet_info() fails when used with descriptor wallets.

* Cause
Bitcoin Core's getwalletinfo command produces a result which sometimes
includes a field called "keypoololdest".
Currently, default wallets have the key but descriptor wallets do not.

* Solution
Making keypool_oldest optional allows this crate to produce the correct
results when operating with descriptor wallets.