### PR TITLE
Update bitcoin types

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
@@ -18,7 +18,7 @@ name = "bitcoincore_rpc"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoincore-rpc-json = { version = "0.14.0", path = "../json" }
+bitcoincore-rpc-json = { version = "0.15.0", path = "../json" }
 
 log = "0.4.5"
 jsonrpc = "0.12.0"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -20,7 +20,7 @@ use serde;
 use serde_json;
 
 use bitcoin::hashes::hex::{FromHex, ToHex};
-use bitcoin::secp256k1::Signature;
+use bitcoin::secp256k1::ecdsa;
 use bitcoin::{
     Address, Amount, Block, BlockHeader, OutPoint, PrivateKey, PublicKey, Script, Transaction,
 };
@@ -815,7 +815,7 @@ pub trait RpcApi: Sized {
     fn verify_message(
         &self,
         address: &Address,
-        signature: &Signature,
+        signature: &ecdsa::Signature,
         message: &str,
     ) -> Result<bool> {
         let args = [address.to_string().into(), signature.to_string().into(), into_json(message)?];
@@ -1008,7 +1008,7 @@ pub trait RpcApi: Sized {
         ];
         let defaults = [
             true.into(),
-            into_json(json::SigHashType::from(bitcoin::SigHashType::All))?,
+            into_json(json::SigHashType::from(bitcoin::EcdsaSighashType::All))?,
             true.into(),
         ];
         self.call("walletprocesspsbt", handle_defaults(&mut args, &defaults))

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Steven Roose <steven@stevenroose.org>"]
 
 [dependencies]
 bitcoincore-rpc = { path = "../client" }
-bitcoin = { version = "0.27", features = [ "use-serde", "rand" ] }
+bitcoin = { version= "0.28.0", features = [ "use-serde", "rand" ] }
 lazy_static = "1.4.0"
 log = "0.4"

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -27,7 +27,7 @@ use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1;
 use bitcoin::{
-    Address, Amount, Network, OutPoint, PrivateKey, Script, SigHashType, SignedAmount, Transaction,
+    Address, Amount, Network, OutPoint, PrivateKey, Script, EcdsaSighashType, SignedAmount, Transaction,
     TxIn, TxOut, Txid,
 };
 use bitcoincore_rpc::bitcoincore_rpc_json::{
@@ -506,7 +506,7 @@ fn test_get_block_filter(cl: &Client) {
 fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
     let sk = PrivateKey {
         network: Network::Regtest,
-        key: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
+        inner: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
         compressed: true,
     };
     let addr = Address::p2wpkh(&sk.public_key(&SECP), Network::Regtest).unwrap();
@@ -528,7 +528,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
             },
             sequence: 0xFFFFFFFF,
             script_sig: Script::new(),
-            witness: Vec::new(),
+            witness: bitcoin::blockdata::witness::Witness::default(),
         }],
         output: vec![TxOut {
             value: (unspent.amount - *FEE).as_sat(),
@@ -557,7 +557,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
             },
             script_sig: Script::new(),
             sequence: 0xFFFFFFFF,
-            witness: Vec::new(),
+            witness: bitcoin::blockdata::witness::Witness::default(),
         }],
         output: vec![TxOut {
             value: (unspent.amount - *FEE - *FEE).as_sat(),
@@ -566,7 +566,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
     };
 
     let res =
-        cl.sign_raw_transaction_with_key(&tx, &[sk], None, Some(SigHashType::All.into())).unwrap();
+        cl.sign_raw_transaction_with_key(&tx, &[sk], None, Some(EcdsaSighashType::All.into())).unwrap();
     assert!(res.complete);
     let _ = cl.send_raw_transaction(&res.transaction().unwrap()).unwrap();
 }
@@ -815,7 +815,7 @@ fn test_list_received_by_address(cl: &Client) {
 fn test_import_public_key(cl: &Client) {
     let sk = PrivateKey {
         network: Network::Regtest,
-        key: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
+        inner: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
         compressed: true,
     };
     cl.import_public_key(&sk.public_key(&SECP), None, None).unwrap();
@@ -826,7 +826,7 @@ fn test_import_public_key(cl: &Client) {
 fn test_import_priv_key(cl: &Client) {
     let sk = PrivateKey {
         network: Network::Regtest,
-        key: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
+        inner: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
         compressed: true,
     };
     cl.import_private_key(&sk, None, None).unwrap();
@@ -837,7 +837,7 @@ fn test_import_priv_key(cl: &Client) {
 fn test_import_address(cl: &Client) {
     let sk = PrivateKey {
         network: Network::Regtest,
-        key: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
+        inner: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
         compressed: true,
     };
     let addr = Address::p2pkh(&sk.public_key(&SECP), Network::Regtest);
@@ -849,7 +849,7 @@ fn test_import_address(cl: &Client) {
 fn test_import_address_script(cl: &Client) {
     let sk = PrivateKey {
         network: Network::Regtest,
-        key: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
+        inner: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
         compressed: true,
     };
     let addr = Address::p2pkh(&sk.public_key(&SECP), Network::Regtest);

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc-json"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
@@ -21,4 +21,4 @@ path = "src/lib.rs"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 
-bitcoin = { version = "0.27", features = [ "use-serde" ] }
+bitcoin = { version= "0.28.0", features = [ "use-serde" ] }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -835,7 +835,7 @@ impl<'a> serde::Serialize for ImportMultiRequestScriptPubkey<'a> {
                 #[derive(Serialize)]
                 struct Tmp<'a> {
                     pub address: &'a Address,
-                };
+                }
                 serde::Serialize::serialize(
                     &Tmp {
                         address: addr,
@@ -1427,10 +1427,10 @@ pub enum EstimateMode {
 
 /// A wrapper around bitcoin::SigHashType that will be serialized
 /// according to what the RPC expects.
-pub struct SigHashType(bitcoin::SigHashType);
+pub struct SigHashType(bitcoin::EcdsaSighashType);
 
-impl From<bitcoin::SigHashType> for SigHashType {
-    fn from(sht: bitcoin::SigHashType) -> SigHashType {
+impl From<bitcoin::EcdsaSighashType> for SigHashType {
+    fn from(sht: bitcoin::EcdsaSighashType) -> SigHashType {
         SigHashType(sht)
     }
 }
@@ -1441,12 +1441,12 @@ impl serde::Serialize for SigHashType {
         S: serde::Serializer,
     {
         serializer.serialize_str(match self.0 {
-            bitcoin::SigHashType::All => "ALL",
-            bitcoin::SigHashType::None => "NONE",
-            bitcoin::SigHashType::Single => "SINGLE",
-            bitcoin::SigHashType::AllPlusAnyoneCanPay => "ALL|ANYONECANPAY",
-            bitcoin::SigHashType::NonePlusAnyoneCanPay => "NONE|ANYONECANPAY",
-            bitcoin::SigHashType::SinglePlusAnyoneCanPay => "SINGLE|ANYONECANPAY",
+            bitcoin::EcdsaSighashType::All => "ALL",
+            bitcoin::EcdsaSighashType::None => "NONE",
+            bitcoin::EcdsaSighashType::Single => "SINGLE",
+            bitcoin::EcdsaSighashType::AllPlusAnyoneCanPay => "ALL|ANYONECANPAY",
+            bitcoin::EcdsaSighashType::NonePlusAnyoneCanPay => "NONE|ANYONECANPAY",
+            bitcoin::EcdsaSighashType::SinglePlusAnyoneCanPay => "SINGLE|ANYONECANPAY",
         })
     }
 }


### PR DESCRIPTION
This does not completely support signing using new taproot APIs, but
 makes the new release compatible with 0.28.0 types.

Many projects have a downstream CI dependent on this. 