### PR TITLE
Enable edition 2018

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,9 @@ jobs:
                     - rust: nightly
                       env:
                           RUSTFMTCHK: false
-                    - rust: 1.29.0
+                    - rust: 1.41.1
                       env:
-                          PIN_VERSIONS: true
+                          RUSTFMTCHK: false
         steps:
             - name: Checkout Crate
               uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -47,16 +47,4 @@ The following versions are officially supported and automatically tested:
 * 0.21.0
 
 # Minimum Supported Rust Version (MSRV)
-This library should always compile with any combination of features on **Rust 1.29**.
-
-Because some dependencies have broken the build in minor/patch releases, to
-compile with 1.29.0 you will need to run the following version-pinning command:
-```
-cargo update --package "cc" --precise "1.0.41"
-cargo update --package "log:0.4.x" --precise "0.4.13" # x being the highest patch version, currently 14
-cargo update --package "cfg-if" --precise "0.1.9"
-cargo update --package "serde_json" --precise "1.0.39"
-cargo update --package "serde" --precise "1.0.98"
-cargo update --package "serde_derive" --precise "1.0.98"
-cargo update --package "byteorder" --precise "1.3.4"
-```
+This library should always compile with any combination of features on **Rust 1.41.1**.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
 description = "RPC client library for the Bitcoin Core JSON-RPC API."
 keywords = ["crypto", "bitcoin", "bitcoin-core", "rpc"]
 readme = "README.md"
+edition = "2018"
 
 [lib]
 name = "bitcoincore_rpc"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -14,21 +14,21 @@ use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::{fmt, result};
 
-use bitcoin;
+use crate::bitcoin;
 use jsonrpc;
 use serde;
 use serde_json;
 
-use bitcoin::hashes::hex::{FromHex, ToHex};
-use bitcoin::secp256k1::ecdsa::Signature;
-use bitcoin::{
+use crate::bitcoin::hashes::hex::{FromHex, ToHex};
+use crate::bitcoin::secp256k1::ecdsa::Signature;
+use crate::bitcoin::{
     Address, Amount, Block, BlockHeader, OutPoint, PrivateKey, PublicKey, Script, Transaction,
 };
 use log::Level::{Debug, Trace, Warn};
 
-use error::*;
-use json;
-use queryable;
+use crate::error::*;
+use crate::json;
+use crate::queryable;
 
 /// Crate-specific Result type, shorthand for `std::result::Result` with our
 /// crate-specific Error type;
@@ -382,7 +382,7 @@ pub trait RpcApi: Sized {
         // - 0.18.x returns a "softforks" array and a "bip9_softforks" map.
         // - 0.19.x returns a "softforks" map.
         Ok(if self.version()? < 190000 {
-            use Error::UnexpectedStructure as err;
+            use crate::Error::UnexpectedStructure as err;
 
             // First, remove both incompatible softfork fields.
             // We need to scope the mutable ref here for v1.29 borrowck.
@@ -1256,12 +1256,12 @@ fn log_response(cmd: &str, resp: &Result<jsonrpc::Response>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin;
+    use crate::bitcoin;
     use serde_json;
 
     #[test]
     fn test_raw_tx() {
-        use bitcoin::consensus::encode;
+        use crate::bitcoin::consensus::encode;
         let client = Client::new("http://localhost/".into(), Auth::None).unwrap();
         let tx: bitcoin::Transaction = encode::deserialize(&Vec::<u8>::from_hex("0200000001586bd02815cf5faabfec986a4e50d25dbee089bd2758621e61c5fab06c334af0000000006b483045022100e85425f6d7c589972ee061413bcf08dc8c8e589ce37b217535a42af924f0e4d602205c9ba9cb14ef15513c9d946fa1c4b797883e748e8c32171bdf6166583946e35c012103dae30a4d7870cd87b45dd53e6012f71318fdd059c1c2623b8cc73f8af287bb2dfeffffff021dc4260c010000001976a914f602e88b2b5901d8aab15ebe4a97cf92ec6e03b388ac00e1f505000000001976a914687ffeffe8cf4e4c038da46a9b1d37db385a472d88acfd211500").unwrap()).unwrap();
 

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -10,9 +10,9 @@
 
 use std::{error, fmt, io};
 
-use bitcoin;
-use bitcoin::hashes::hex;
-use bitcoin::secp256k1;
+use crate::bitcoin;
+use crate::bitcoin::hashes::hex;
+use crate::bitcoin::secp256k1;
 use jsonrpc;
 use serde_json;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -26,13 +26,13 @@ extern crate serde_json;
 pub extern crate jsonrpc;
 
 pub extern crate bitcoincore_rpc_json;
+pub use crate::json::bitcoin;
 pub use bitcoincore_rpc_json as json;
-pub use json::bitcoin;
 
 mod client;
 mod error;
 mod queryable;
 
-pub use client::*;
-pub use error::Error;
-pub use queryable::*;
+pub use crate::client::*;
+pub use crate::error::Error;
+pub use crate::queryable::*;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -21,7 +21,6 @@ extern crate log;
 #[allow(unused)]
 #[macro_use] // `macro_use` is needed for v1.24.0 compilation.
 extern crate serde;
-extern crate serde_json;
 
 pub extern crate jsonrpc;
 

--- a/client/src/queryable.rs
+++ b/client/src/queryable.rs
@@ -8,11 +8,11 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use bitcoin;
+use crate::bitcoin;
 use serde_json;
 
-use client::Result;
-use client::RpcApi;
+use crate::client::Result;
+use crate::client::RpcApi;
 
 /// A type that can be queried from Bitcoin Core.
 pub trait Queryable<C: RpcApi>: Sized {
@@ -44,7 +44,7 @@ impl<C: RpcApi> Queryable<C> for bitcoin::blockdata::transaction::Transaction {
     }
 }
 
-impl<C: RpcApi> Queryable<C> for Option<::json::GetTxOutResult> {
+impl<C: RpcApi> Queryable<C> for Option<crate::json::GetTxOutResult> {
     type Id = bitcoin::OutPoint;
 
     fn query(rpc: &C, id: &Self::Id) -> Result<Self> {

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -6,20 +6,6 @@ echo "RUSTFMTCHECK: \"$RUSTFMTCHECK\""
 echo "BITCOINVERSION: \"$BITCOINVERSION\""
 echo "PATH: \"$PATH\""
 
-
-# Pin dependencies for Rust v1.29
-if [ -n $"$PIN_VERSIONS" ]; then
-    cargo generate-lockfile --verbose
-
-    cargo update --verbose --package "log" --precise "0.4.13"
-    cargo update --verbose --package "cc" --precise "1.0.41"
-    cargo update --verbose --package "cfg-if" --precise "0.1.9"
-    cargo update --verbose --package "serde_json" --precise "1.0.39"
-    cargo update --verbose --package "serde" --precise "1.0.98"
-    cargo update --verbose --package "serde_derive" --precise "1.0.98"
-    cargo update --verbose --package "byteorder" --precise "1.3.4"
-fi
-
 if [ -n "$RUSTFMTCHECK" ]; then
   rustup component add rustfmt
   cargo fmt --all -- --check

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "integration_test"
 version = "0.1.0"
 authors = ["Steven Roose <steven@stevenroose.org>"]
+edition = "2018"
 
 [dependencies]
 bitcoincore-rpc = { path = "../client" }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -27,8 +27,8 @@ use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1;
 use bitcoin::{
-    Address, Amount, Network, OutPoint, PrivateKey, Script, EcdsaSighashType, SignedAmount, Transaction,
-    TxIn, TxOut, Txid, Witness,
+    Address, Amount, EcdsaSighashType, Network, OutPoint, PrivateKey, Script, SignedAmount,
+    Transaction, TxIn, TxOut, Txid, Witness,
 };
 use bitcoincore_rpc::bitcoincore_rpc_json::{
     GetBlockTemplateModes, GetBlockTemplateRules, ScanTxOutRequest,
@@ -596,8 +596,9 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
         }],
     };
 
-    let res =
-        cl.sign_raw_transaction_with_key(&tx, &[sk], None, Some(EcdsaSighashType::All.into())).unwrap();
+    let res = cl
+        .sign_raw_transaction_with_key(&tx, &[sk], None, Some(EcdsaSighashType::All.into()))
+        .unwrap();
     assert!(res.complete);
     let _ = cl.send_raw_transaction(&res.transaction().unwrap()).unwrap();
 }
@@ -1081,11 +1082,7 @@ fn test_add_ban(cl: &Client) {
     let res = cl.list_banned().unwrap();
     assert_eq!(res.len(), 0);
 
-    assert_error_message!(
-        cl.add_ban("INVALID_STRING", 0, false),
-        -30,
-        "Error: Invalid IP/Subnet"
-    );
+    assert_error_message!(cl.add_ban("INVALID_STRING", 0, false), -30, "Error: Invalid IP/Subnet");
 }
 
 fn test_set_network_active(cl: &Client) {

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -10,11 +10,8 @@
 
 #![deny(unused)]
 
-extern crate bitcoin;
-extern crate bitcoincore_rpc;
 #[macro_use]
 extern crate lazy_static;
-extern crate log;
 
 use std::collections::HashMap;
 

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -22,6 +22,7 @@ use bitcoincore_rpc::json;
 use bitcoincore_rpc::jsonrpc::error::Error as JsonRpcError;
 use bitcoincore_rpc::{Auth, Client, Error, RpcApi};
 
+use crate::json::BlockStatsFields as BsFields;
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::Hash;
@@ -33,7 +34,6 @@ use bitcoin::{
 use bitcoincore_rpc::bitcoincore_rpc_json::{
     GetBlockTemplateModes, GetBlockTemplateRules, ScanTxOutRequest,
 };
-use json::BlockStatsFields as BsFields;
 
 lazy_static! {
     static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
 description = "JSON-enabled type structs for bitcoincore-rpc crate."
 keywords = [ "crypto", "bitcoin", "bitcoin-core", "rpc" ]
 readme = "README.md"
+edition = "2018"
 
 [lib]
 name = "bitcoincore_rpc_json"

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -184,7 +184,7 @@ pub struct GetBlockResult {
     pub weight: usize,
     pub height: usize,
     pub version: i32,
-    #[serde(default, with = "::serde_hex::opt")]
+    #[serde(default, with = "crate::serde_hex::opt")]
     pub version_hex: Option<Vec<u8>>,
     pub merkleroot: bitcoin::TxMerkleNode,
     pub tx: Vec<bitcoin::Txid>,
@@ -193,7 +193,7 @@ pub struct GetBlockResult {
     pub nonce: u32,
     pub bits: String,
     pub difficulty: f64,
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub chainwork: Vec<u8>,
     pub n_tx: usize,
     pub previousblockhash: Option<bitcoin::BlockHash>,
@@ -207,7 +207,7 @@ pub struct GetBlockHeaderResult {
     pub confirmations: i32,
     pub height: usize,
     pub version: i32,
-    #[serde(default, with = "::serde_hex::opt")]
+    #[serde(default, with = "crate::serde_hex::opt")]
     pub version_hex: Option<Vec<u8>>,
     #[serde(rename = "merkleroot")]
     pub merkle_root: bitcoin::TxMerkleNode,
@@ -217,7 +217,7 @@ pub struct GetBlockHeaderResult {
     pub nonce: u32,
     pub bits: String,
     pub difficulty: f64,
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub chainwork: Vec<u8>,
     pub n_tx: usize,
     #[serde(rename = "previousblockhash")]
@@ -505,7 +505,7 @@ pub struct GetMiningInfoResult {
 #[serde(rename_all = "camelCase")]
 pub struct GetRawTransactionResultVinScriptSig {
     pub asm: String,
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub hex: Vec<u8>,
 }
 
@@ -520,7 +520,7 @@ impl GetRawTransactionResultVinScriptSig {
 pub struct GetRawTransactionResultVin {
     pub sequence: u32,
     /// The raw scriptSig in case of a coinbase tx.
-    #[serde(default, with = "::serde_hex::opt")]
+    #[serde(default, with = "crate::serde_hex::opt")]
     pub coinbase: Option<Vec<u8>>,
     /// Not provided for coinbase txs.
     pub txid: Option<bitcoin::Txid>,
@@ -546,7 +546,7 @@ impl GetRawTransactionResultVin {
 #[serde(rename_all = "camelCase")]
 pub struct GetRawTransactionResultVoutScriptPubKey {
     pub asm: String,
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub hex: Vec<u8>,
     pub req_sigs: Option<usize>,
     #[serde(rename = "type")]
@@ -574,7 +574,7 @@ pub struct GetRawTransactionResultVout {
 pub struct GetRawTransactionResult {
     #[serde(rename = "in_active_chain")]
     pub in_active_chain: Option<bool>,
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub hex: Vec<u8>,
     pub txid: bitcoin::Txid,
     pub hash: bitcoin::Wtxid,
@@ -593,7 +593,7 @@ pub struct GetRawTransactionResult {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct GetBlockFilterResult {
     pub header: bitcoin::FilterHash,
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub filter: Vec<u8>,
 }
 
@@ -683,7 +683,7 @@ pub struct GetTransactionResult {
     #[serde(default, with = "bitcoin::util::amount::serde::as_btc::opt")]
     pub fee: Option<SignedAmount>,
     pub details: Vec<GetTransactionResultDetail>,
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub hex: Vec<u8>,
 }
 
@@ -794,7 +794,7 @@ pub struct SignRawTransactionResultError {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SignRawTransactionResult {
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub hex: Vec<u8>,
     pub complete: bool,
     pub errors: Option<Vec<SignRawTransactionResultError>>,
@@ -901,11 +901,11 @@ pub struct GetAddressInfoResultEmbedded {
     #[serde(rename = "is_witness")]
     pub is_witness: Option<bool>,
     pub witness_version: Option<u32>,
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub witness_program: Vec<u8>,
     pub script: Option<ScriptPubkeyType>,
     /// The redeemscript for the p2sh address.
-    #[serde(default, with = "::serde_hex::opt")]
+    #[serde(default, with = "crate::serde_hex::opt")]
     pub hex: Option<Vec<u8>>,
     pub pubkeys: Option<Vec<PublicKey>>,
     #[serde(rename = "sigsrequired")]
@@ -953,11 +953,11 @@ pub struct GetAddressInfoResult {
     #[serde(rename = "iswitness")]
     pub is_witness: Option<bool>,
     pub witness_version: Option<u32>,
-    #[serde(default, with = "::serde_hex::opt")]
+    #[serde(default, with = "crate::serde_hex::opt")]
     pub witness_program: Option<Vec<u8>>,
     pub script: Option<ScriptPubkeyType>,
     /// The redeemscript for the p2sh address.
-    #[serde(default, with = "::serde_hex::opt")]
+    #[serde(default, with = "crate::serde_hex::opt")]
     pub hex: Option<Vec<u8>>,
     pub pubkeys: Option<Vec<PublicKey>>,
     #[serde(rename = "sigsrequired")]
@@ -1002,7 +1002,7 @@ pub struct GetBlockchainInfoResult {
     #[serde(rename = "initialblockdownload")]
     pub initial_block_download: bool,
     /// Total amount of work in active chain, in hexadecimal
-    #[serde(rename = "chainwork", with = "::serde_hex")]
+    #[serde(rename = "chainwork", with = "crate::serde_hex")]
     pub chain_work: Vec<u8>,
     /// The estimated size of the block and undo files on disk
     pub size_on_disk: u64,
@@ -1474,7 +1474,7 @@ pub enum GetBlockTemplateModes {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct GetBlockTemplateResult {
     /// The compressed difficulty in hexadecimal
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub bits: Vec<u8>,
     /// The previous block hash the current template is mining on
     #[serde(rename = "previousblockhash")]
@@ -1530,7 +1530,7 @@ pub struct GetBlockTemplateResult {
     #[serde(rename = "coinbasevalue", with = "bitcoin::util::amount::serde::as_sat", default)]
     pub coinbase_value: Amount,
     /// The number which valid hashes must be less than, in big-endian
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub target: Vec<u8>,
     /// The minimum timestamp appropriate for the next block time. Expressed as
     /// UNIX timestamp.
@@ -1540,7 +1540,7 @@ pub struct GetBlockTemplateResult {
     /// block
     pub mutable: Vec<GetBlockTemplateResulMutations>,
     /// A range of valid nonces
-    #[serde(with = "::serde_hex", rename = "noncerange")]
+    #[serde(with = "crate::serde_hex", rename = "noncerange")]
     pub nonce_range: Vec<u8>,
 }
 
@@ -1553,7 +1553,7 @@ pub struct GetBlockTemplateResultTransaction {
     #[serde(rename = "hash")]
     pub wtxid: bitcoin::Wtxid,
     /// The serilaized transaction bytes
-    #[serde(with = "::serde_hex", rename = "data")]
+    #[serde(with = "crate::serde_hex", rename = "data")]
     pub raw_tx: Vec<u8>,
     // The transaction fee
     #[serde(with = "bitcoin::util::amount::serde::as_sat")]
@@ -1677,7 +1677,7 @@ pub struct WalletCreateFundedPsbtOptions {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct FinalizePsbtResult {
     pub psbt: Option<String>,
-    #[serde(default, with = "::serde_hex::opt")]
+    #[serde(default, with = "crate::serde_hex::opt")]
     pub hex: Option<Vec<u8>>,
     pub complete: bool,
 }
@@ -1804,7 +1804,7 @@ pub struct FundRawTransactionOptions {
 #[derive(Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct FundRawTransactionResult {
-    #[serde(with = "::serde_hex")]
+    #[serde(with = "crate::serde_hex")]
     pub hex: Vec<u8>,
     #[serde(with = "bitcoin::util::amount::serde::as_btc")]
     pub fee: Amount,


### PR DESCRIPTION
The rust-bitcoin stack is moving to a MSRV of 1.41.1

Do a [reasonably minimal] patch set that enables editon 2018

- Patch 1 - Preparatory cleanup
- Patch 2 - Update CI, README, and test script
- Patch 3 - Run `cargo fix --edition`
- Patch 4 - Enable edition 2018