### PR TITLE
Upgrade bitcoin dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.16.0
+
+- bump bitcoin crate version to 0.29.0
 
 # 0.15.0
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
@@ -19,7 +19,7 @@ name = "bitcoincore_rpc"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoincore-rpc-json = { version = "0.15.0", path = "../json" }
+bitcoincore-rpc-json = { version = "0.16.0", path = "../json" }
 
 log = "0.4.5"
 jsonrpc = "0.12.0"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -730,7 +730,7 @@ pub trait RpcApi: Sized {
         replaceable: Option<bool>,
     ) -> Result<String> {
         let outs_converted = serde_json::Map::from_iter(
-            outs.iter().map(|(k, v)| (k.clone(), serde_json::Value::from(v.as_btc()))),
+            outs.iter().map(|(k, v)| (k.clone(), serde_json::Value::from(v.to_btc()))),
         );
         let mut args = [
             into_json(utxos)?,
@@ -903,7 +903,7 @@ pub trait RpcApi: Sized {
     ) -> Result<bitcoin::Txid> {
         let mut args = [
             address.to_string().into(),
-            into_json(amount.as_btc())?,
+            into_json(amount.to_btc())?,
             opt_into_json(comment)?,
             opt_into_json(comment_to)?,
             opt_into_json(subtract_fee)?,
@@ -1061,7 +1061,7 @@ pub trait RpcApi: Sized {
         bip32derivs: Option<bool>,
     ) -> Result<json::WalletCreateFundedPsbtResult> {
         let outputs_converted = serde_json::Map::from_iter(
-            outputs.iter().map(|(k, v)| (k.clone(), serde_json::Value::from(v.as_btc()))),
+            outputs.iter().map(|(k, v)| (k.clone(), serde_json::Value::from(v.to_btc()))),
         );
         let mut args = [
             into_json(inputs)?,

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 bitcoincore-rpc = { path = "../client" }
-bitcoin = { version = "0.28.0", features = [ "use-serde", "rand" ] }
+bitcoin = { version = "0.29.0", features = ["serde", "rand"]}
 lazy_static = "1.4.0"
 log = "0.4"

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -25,8 +25,8 @@ use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1;
 use bitcoin::{
-    Address, Amount, EcdsaSighashType, Network, OutPoint, PrivateKey, Script, SignedAmount,
-    Transaction, TxIn, TxOut, Txid, Witness,
+    Address, Amount, PackedLockTime, Network, OutPoint, PrivateKey, Script, EcdsaSighashType, SignedAmount,
+    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use bitcoincore_rpc::bitcoincore_rpc_json::{
     GetBlockTemplateModes, GetBlockTemplateRules, ScanTxOutRequest,
@@ -548,18 +548,18 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
 
     let tx = Transaction {
         version: 1,
-        lock_time: 0,
+        lock_time: PackedLockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
                 txid: unspent.txid,
                 vout: unspent.vout,
             },
-            sequence: 0xFFFFFFFF,
+            sequence: Sequence::MAX,
             script_sig: Script::new(),
             witness: Witness::new(),
         }],
         output: vec![TxOut {
-            value: (unspent.amount - *FEE).as_sat(),
+            value: (unspent.amount - *FEE).to_sat(),
             script_pubkey: addr.script_pubkey(),
         }],
     };
@@ -577,18 +577,18 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
 
     let tx = Transaction {
         version: 1,
-        lock_time: 0,
+        lock_time: PackedLockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
                 txid: txid,
                 vout: 0,
             },
             script_sig: Script::new(),
-            sequence: 0xFFFFFFFF,
+            sequence: Sequence::MAX,
             witness: Witness::new(),
         }],
         output: vec![TxOut {
-            value: (unspent.amount - *FEE - *FEE).as_sat(),
+            value: (unspent.amount - *FEE - *FEE).to_sat(),
             script_pubkey: RANDOM_ADDRESS.script_pubkey(),
         }],
     };

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc-json"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -22,4 +22,4 @@ path = "src/lib.rs"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 
-bitcoin = { version = "0.28.0", features = [ "use-serde" ] }
+bitcoin = { version = "0.29.0", features = ["serde"]}


### PR DESCRIPTION
This update breaks MSRV 1.29 so cannot be merged until we merge: https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/222

Upgrade `rust-bitcoin` dependency to the newly released version (0.29.0). Includes fixing newly deprecated APIs.

- Patch one does the upgrade
- Patch two bumps the crate version and adds release notes