### PR TITLE
Deserialize hexes without allocating intermediate `Vec<u8>`

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -14,7 +14,7 @@ use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::{fmt, result};
 
-use crate::bitcoin;
+use crate::{bitcoin, deserialize_hex};
 use jsonrpc;
 use serde;
 use serde_json;
@@ -321,8 +321,7 @@ pub trait RpcApi: Sized {
 
     fn get_block(&self, hash: &bitcoin::BlockHash) -> Result<Block> {
         let hex: String = self.call("getblock", &[into_json(hash)?, 0.into()])?;
-        let bytes: Vec<u8> = FromHex::from_hex(&hex)?;
-        Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
+        deserialize_hex(&hex)
     }
 
     fn get_block_hex(&self, hash: &bitcoin::BlockHash) -> Result<String> {
@@ -336,8 +335,7 @@ pub trait RpcApi: Sized {
 
     fn get_block_header(&self, hash: &bitcoin::BlockHash) -> Result<BlockHeader> {
         let hex: String = self.call("getblockheader", &[into_json(hash)?, false.into()])?;
-        let bytes: Vec<u8> = FromHex::from_hex(&hex)?;
-        Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
+        deserialize_hex(&hex)
     }
 
     fn get_block_header_info(
@@ -481,8 +479,7 @@ pub trait RpcApi: Sized {
     ) -> Result<Transaction> {
         let mut args = [into_json(txid)?, into_json(false)?, opt_into_json(block_hash)?];
         let hex: String = self.call("getrawtransaction", handle_defaults(&mut args, &[null()]))?;
-        let bytes: Vec<u8> = FromHex::from_hex(&hex)?;
-        Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
+        deserialize_hex(&hex)
     }
 
     fn get_raw_transaction_hex(
@@ -750,8 +747,7 @@ pub trait RpcApi: Sized {
         replaceable: Option<bool>,
     ) -> Result<Transaction> {
         let hex: String = self.create_raw_transaction_hex(utxos, outs, locktime, replaceable)?;
-        let bytes: Vec<u8> = FromHex::from_hex(&hex)?;
-        Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
+        deserialize_hex(&hex)
     }
 
     fn fund_raw_transaction<R: RawTx>(

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -27,6 +27,8 @@ pub extern crate jsonrpc;
 pub extern crate bitcoincore_rpc_json;
 pub use crate::json::bitcoin;
 pub use bitcoincore_rpc_json as json;
+use json::bitcoin::consensus::{Decodable, ReadExt};
+use json::bitcoin::hashes::hex::HexIterator;
 
 mod client;
 mod error;
@@ -35,3 +37,13 @@ mod queryable;
 pub use crate::client::*;
 pub use crate::error::Error;
 pub use crate::queryable::*;
+
+fn deserialize_hex<T: Decodable>(hex: &str) -> Result<T> {
+    let mut reader = HexIterator::new(&hex)?;
+    let object = Decodable::consensus_decode(&mut reader)?;
+    if reader.read_u8().is_ok() {
+        Err(Error::BitcoinSerialization(bitcoin::consensus::encode::Error::ParseFailed("data not consumed entirely when explicitly deserializing")))
+    } else {
+        Ok(object)
+    }
+}


### PR DESCRIPTION
Since `HexIterator` is `Read` we can feed it directly to `consensus_decode`
without the intermediate step of converting the hex string to `Vec<u8>`

Could be applied on other fields, but they are now deserialized with `serde_hex` as `Vec<u8>`, we may consider keeping them `String` and then converting them with `deserialize_hex`