### PR TITLE
Adds importdescriptors

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -658,6 +658,14 @@ pub trait RpcApi: Sized {
         self.call("importmulti", handle_defaults(&mut args, &[null()]))
     }
 
+    fn import_descriptors(
+        &self,
+        req: json::ImportDescriptors,
+    ) -> Result<Vec<json::ImportMultiResult>> {
+        let json_request = vec![serde_json::to_value(req)?];
+        self.call("importdescriptors", handle_defaults(&mut [json_request.into()], &[null()]))
+    }
+
     fn set_label(&self, address: &Address, label: &str) -> Result<()> {
         self.call("setlabel", &[address.to_string().into(), label.into()])
     }


### PR DESCRIPTION
Adds `importdescriptors` rpc. I've renamed `ImportMultiRescanSince` to `Timestamp` given it is not being used solely for multi rescan anymore.

Feels like `ImportMultiResult` should also be renamed, given it is now used by both `importmulti` and `importdescriptors`. I haven't found a proper name for it though.