### PR TITLE
Bump crate version to `v0.17.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.17.0
+
+- Add listwalletdir rpc
+- Update `jsonrpc` dependency to 0.14.0
+
 # 0.16.0
 
 - MSRV changed from 1.29 to 1.41.1

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 bitcoincore-rpc-json = { version = "0.16.0", path = "../json" }
 
 log = "0.4.5"
-jsonrpc = "0.13.0"
+jsonrpc = "0.14.0"
 
 # Used for deserialization of JSON.
 serde = "1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc"
-version = "0.16.0"
+version = "0.17.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",
@@ -19,7 +19,7 @@ name = "bitcoincore_rpc"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoincore-rpc-json = { version = "0.16.0", path = "../json" }
+bitcoincore-rpc-json = { version = "0.17.0", path = "../json" }
 
 log = "0.4.5"
 jsonrpc = "0.14.0"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc-json"
-version = "0.16.0"
+version = "0.17.0"
 authors = [
     "Steven Roose <steven@stevenroose.org>",
     "Jean Pierre Dudey <jeandudey@hotmail.com>",


### PR DESCRIPTION
Add release notes and increase the crate minor version to 0.17.0

Justified because we just bumped the `rust-jsonrpc` minor version.


- Patch 1 updates `rust-jsonrpc` dependency to current version
- Patch 2 does the release