### PR TITLE
use minreq instead of jsonrpc http implementation

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,7 +23,8 @@ bitcoincore-rpc-json = { version = "0.16.0", path = "../json" }
 
 log = "0.4.5"
 jsonrpc = "0.13.0"
-
+minreq = "2.6.0"
 # Used for deserialization of JSON.
 serde = "1"
-serde_json = "1"
+serde_json  = {version = "1", features = ["raw_value"]}
+base64 = { version = "0.13.0" }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -13,13 +13,13 @@ use std::{error, fmt, io};
 use crate::bitcoin;
 use crate::bitcoin::hashes::hex;
 use crate::bitcoin::secp256k1;
-use jsonrpc;
 use serde_json;
 
 /// The error type for errors produced in this library.
 #[derive(Debug)]
 pub enum Error {
     JsonRpc(jsonrpc::error::Error),
+    Http(minreq::Error),
     Hex(hex::Error),
     Json(serde_json::error::Error),
     BitcoinSerialization(bitcoin::consensus::encode::Error),
@@ -79,6 +79,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::JsonRpc(ref e) => write!(f, "JSON-RPC error: {}", e),
+            Error::Http(ref e) => write!(f, "HTTP error: {}", e),
             Error::Hex(ref e) => write!(f, "hex decode error: {}", e),
             Error::Json(ref e) => write!(f, "JSON error: {}", e),
             Error::BitcoinSerialization(ref e) => write!(f, "Bitcoin serialization error: {}", e),


### PR DESCRIPTION
The jsonrpc http implementation is hand rolled and has a number of "basic" http issues that we shouldn't have to deal with (missing common headers, content-length parsing issue, etc).

I replaced it with the simple most popular rust HTTP client, reqwest.