### PR TITLE
List transaction result round trip

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2084,7 +2084,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn list_transaction_result_round_trip() {
+    fn list_transaction_result_round_trip_error() {
         let value = ListTransactionResult {
             info: WalletTxInfo {
                 confirmations: 0,
@@ -2116,5 +2116,22 @@ mod tests {
         let json = serde_json::to_string(&value).unwrap();
 
         serde_json::from_str::<ListTransactionResult>(&json).unwrap();
+    }
+
+    #[test]
+    fn get_transaction_result_detail_ok() {
+        let value = GetTransactionResultDetail {
+            address: None,
+            category: GetTransactionResultDetailCategory::Immature,
+            amount: SignedAmount::from_sat(0),
+            label: None,
+            vout: 0,
+            fee: None,
+            abandoned: None,
+        };
+
+        let json = serde_json::to_string(&value).unwrap();
+
+        serde_json::from_str::<GetTransactionResultDetail>(&json).unwrap();
     }
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -659,7 +659,7 @@ pub enum GetTransactionResultDetailCategory {
     Orphan,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct GetTransactionResultDetail {
     pub address: Option<Address>,
     pub category: GetTransactionResultDetailCategory,
@@ -672,7 +672,7 @@ pub struct GetTransactionResultDetail {
     pub abandoned: Option<bool>,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct WalletTxInfo {
     pub confirmations: i32,
     pub blockhash: Option<bitcoin::BlockHash>,
@@ -708,7 +708,7 @@ impl GetTransactionResult {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct ListTransactionResult {
     #[serde(flatten)]
     pub info: WalletTxInfo,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2078,3 +2078,43 @@ where
     }
     Ok(Some(res))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_transaction_result_round_trip() {
+        let value = ListTransactionResult {
+            info: WalletTxInfo {
+                confirmations: 0,
+                blockhash: None,
+                blockindex: None,
+                blocktime: None,
+                blockheight: None,
+                txid: "0000000000000000000000000000000000000000000000000000000000000000"
+                    .parse()
+                    .unwrap(),
+                time: 0,
+                timereceived: 0,
+                bip125_replaceable: Bip125Replaceable::Unknown,
+                wallet_conflicts: Vec::new(),
+            },
+            detail: GetTransactionResultDetail {
+                address: None,
+                category: GetTransactionResultDetailCategory::Immature,
+                amount: SignedAmount::from_sat(0),
+                label: None,
+                vout: 0,
+                fee: None,
+                abandoned: None,
+            },
+            trusted: None,
+            comment: None,
+        };
+
+        let json = serde_json::to_string(&value).unwrap();
+
+        serde_json::from_str::<ListTransactionResult>(&json).unwrap();
+    }
+}


### PR DESCRIPTION
I'm using rust-bitcoincore-rpc in a project where we implement a mock Bitcoin Core RPC server for testing.

While implementing our mocked version of `listtransaction`, we ran into an issue where the client fails to deserialize `ListTransactionResult` from serialized JSON.

This PR shows a minimal reproduction:

- Derive serialize for ListTransactionResult
- Add a failing test showing that ListTransactionResult can't be round-tripped from JSON
- Add a test showing that GeTransactionResultDetail can be round tripped

The offending field is `ListTransactionResult::fee`. I'm not sure what's going on, but I think it's an interaction between serde flatten and serde with.

Is this worth trying to fix? This is an edge case, and we can work around it by always making the `fee` field `Some`, but it is extremely confusing and hard to track down if you happen to hit it.