### PR TITLE
Expose JsonOutPoint

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -34,8 +34,10 @@ use crate::queryable;
 /// crate-specific Error type;
 pub type Result<T> = result::Result<T, Error>;
 
+/// Outpoint that serializes and deserializes as a map, instead of a string,
+/// for use as RPC arguments
 #[derive(Clone, Debug, Serialize, Deserialize)]
-struct JsonOutPoint {
+pub struct JsonOutPoint {
     pub txid: bitcoin::Txid,
     pub vout: u32,
 }


### PR DESCRIPTION
I'm implementing an in-memory dummy Bitcoin Core RPC server for testing. Exposing `JsonOutPoint` is necessary in order to implement `lockunspent`, which takes `JsonOutPoint`s instead of `OutPoint`s.