### PR TITLE
Update `jsonrpc` to `0.14`

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 bitcoincore-rpc-json = { version = "0.16.0", path = "../json" }
 
 log = "0.4.5"
-jsonrpc = "0.13.0"
+jsonrpc = "0.14.0"
 
 # Used for deserialization of JSON.
 serde = "1"


### PR DESCRIPTION
This PR updates `jsonrpc` to `0.14`.
Reason: Apparently, https://github.com/apoelstra/rust-jsonrpc/issues/67 was fixed by https://github.com/apoelstra/rust-jsonrpc/pull/72, which was included in version `0.14`.