### PR TITLE
Added get_index_info rpc call

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -237,6 +237,10 @@ pub trait RpcApi: Sized {
         self.call("getnetworkinfo", &[])
     }
 
+    fn get_index_info(&self) -> Result<json::GetIndexInfoResult> {
+        self.call("getindexinfo", &[])
+    }
+
     fn version(&self) -> Result<usize> {
         #[derive(Deserialize)]
         struct Response {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2117,6 +2117,20 @@ pub struct Utxo {
     pub height: u64,
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct IndexStatus {
+    pub synced: bool,
+    pub best_block_height: u32,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct GetIndexInfoResult {
+    pub txindex: IndexStatus,
+    pub coinstatsindex: IndexStatus,
+    #[serde(rename = "basic block filter index")]
+    pub basic_block_filter_index: IndexStatus,
+}
+
 impl<'a> serde::Serialize for PubKeyOrAddress<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Added get_index_info rpc call for the three known indexes: txindex, coinstatsindex and basic block filter index.