### PR TITLE
Take all get_index_info rpc call return values as Option<>

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2125,10 +2125,10 @@ pub struct IndexStatus {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct GetIndexInfoResult {
-    pub txindex: IndexStatus,
-    pub coinstatsindex: IndexStatus,
+    pub txindex: Option<IndexStatus>,
+    pub coinstatsindex: Option<IndexStatus>,
     #[serde(rename = "basic block filter index")]
-    pub basic_block_filter_index: IndexStatus,
+    pub basic_block_filter_index: Option<IndexStatus>,
 }
 
 impl<'a> serde::Serialize for PubKeyOrAddress<'a> {


### PR DESCRIPTION
The values returned by get_index_info are optional depending on whether the values txindex=1, blockfilterindex=1, and coinstatsindex=1 are configured in bitcoin.conf.

This causes the library to fail in case any of these indices are not configured.