### PR TITLE
Take all get_index_info rpc call return values as Option<>

### DIFF
--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -215,6 +215,7 @@ fn main() {
     test_disconnect_node(&cl);
     test_add_ban(&cl);
     test_set_network_active(&cl);
+    test_get_index_info(&cl);
     test_stop(cl);
 }
 
@@ -1260,6 +1261,15 @@ fn test_getblocktemplate(cl: &Client) {
 
     // cleanup mempool transaction
     cl.generate_to_address(2, &RANDOM_ADDRESS).unwrap();
+}
+
+fn test_get_index_info(cl: &Client) {
+    if version() >= 210000 {
+        let gii = cl.get_index_info().unwrap();
+        assert!(gii.txindex.is_some());
+        assert!(gii.coinstatsindex.is_none());
+        assert!(gii.basic_block_filter_index.is_some());
+    }
 }
 
 fn test_stop(cl: Client) {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2125,10 +2125,10 @@ pub struct IndexStatus {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct GetIndexInfoResult {
-    pub txindex: IndexStatus,
-    pub coinstatsindex: IndexStatus,
+    pub txindex: Option<IndexStatus>,
+    pub coinstatsindex: Option<IndexStatus>,
     #[serde(rename = "basic block filter index")]
-    pub basic_block_filter_index: IndexStatus,
+    pub basic_block_filter_index: Option<IndexStatus>,
 }
 
 impl<'a> serde::Serialize for PubKeyOrAddress<'a> {


### PR DESCRIPTION
The values returned by get_index_info are optional depending on whether the values txindex=1, blockfilterindex=1, and coinstatsindex=1 are configured in bitcoin.conf.

This causes the library to fail in case any of these indices are not configured.

I closed last pull request due to problems with rebase.