### PR TITLE
add getzmqnotifications rpc

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1261,6 +1261,11 @@ pub trait RpcApi: Sized {
     ) -> Result<json::ScanTxOutResult> {
         self.call("scantxoutset", &["start".into(), into_json(descriptors)?])
     }
+
+    /// Returns information about the active ZeroMQ notifications
+    fn get_zmq_notifications(&self) -> Result<Vec<json::GetZmqNotificationsResult>> {
+        self.call("getzmqnotifications", &[])
+    }
 }
 
 /// Client implements a JSON-RPC client for the Bitcoin Core daemon or compatible APIs.

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -34,7 +34,9 @@ bitcoind -regtest $BLOCKFILTERARG $FALLBACKFEEARG \
     -rpcport=12349 \
     -server=1 \
     -txindex=1 \
-    -printtoconsole=0 &
+    -printtoconsole=0 \
+    -zmqpubrawblock=tcp://0.0.0.0:28332 \
+    -zmqpubrawtx=tcp://0.0.0.0:28333 &
 PID2=$!
 
 # Let it connect to the other node.

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2140,6 +2140,14 @@ pub struct GetIndexInfoResult {
     pub basic_block_filter_index: Option<IndexStatus>,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct GetZmqNotificationsResult {
+    #[serde(rename = "type")]
+    pub notification_type: String,
+    pub address: String,
+    pub hwm: u64,
+}
+
 impl<'a> serde::Serialize for PubKeyOrAddress<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
this rpc gives information about the active zmq publishers of bitcoin core

currently `get_zmq_notifications` returns a Vec directly from bitcoind, but a structure like getindexinfo could also be used because the possible values of the "type" field are known