### PR TITLE
WIP: Upgrade the bitcoin dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "client",
     "integration_test",
 ]
+
+[patch.crates-io.bitcoin]
+path = "../rust-bitcoin/bitcoin"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -14,14 +14,14 @@ use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::{fmt, result};
 
-use crate::{bitcoin, deserialize_hex};
-use bitcoin_private::hex::exts::DisplayHex;
+use crate::bitcoin::{self, consensus};
+use bitcoin::hex::DisplayHex;
 use jsonrpc;
 use serde;
 use serde_json;
 
 use crate::bitcoin::address::{NetworkUnchecked, NetworkChecked};
-use crate::bitcoin::hashes::hex::FromHex;
+use crate::bitcoin::hex::FromHex;
 use crate::bitcoin::secp256k1::ecdsa::Signature;
 use crate::bitcoin::{
     Address, Amount, Block, OutPoint, PrivateKey, PublicKey, Script, Transaction,
@@ -335,7 +335,7 @@ pub trait RpcApi: Sized {
 
     fn get_block(&self, hash: &bitcoin::BlockHash) -> Result<Block> {
         let hex: String = self.call("getblock", &[into_json(hash)?, 0.into()])?;
-        deserialize_hex(&hex)
+        Ok(consensus::deserialize_hex(&hex)?)
     }
 
     fn get_block_hex(&self, hash: &bitcoin::BlockHash) -> Result<String> {
@@ -349,7 +349,7 @@ pub trait RpcApi: Sized {
 
     fn get_block_header(&self, hash: &bitcoin::BlockHash) -> Result<bitcoin::block::Header> {
         let hex: String = self.call("getblockheader", &[into_json(hash)?, false.into()])?;
-        deserialize_hex(&hex)
+        Ok(consensus::deserialize_hex(&hex)?)
     }
 
     fn get_block_header_info(
@@ -493,7 +493,7 @@ pub trait RpcApi: Sized {
     ) -> Result<Transaction> {
         let mut args = [into_json(txid)?, into_json(false)?, opt_into_json(block_hash)?];
         let hex: String = self.call("getrawtransaction", handle_defaults(&mut args, &[null()]))?;
-        deserialize_hex(&hex)
+        Ok(consensus::deserialize_hex(&hex)?)
     }
 
     fn get_raw_transaction_hex(
@@ -790,7 +790,7 @@ pub trait RpcApi: Sized {
         replaceable: Option<bool>,
     ) -> Result<Transaction> {
         let hex: String = self.create_raw_transaction_hex(utxos, outs, locktime, replaceable)?;
-        deserialize_hex(&hex)
+        Ok(consensus::deserialize_hex(&hex)?)
     }
 
     fn decode_raw_transaction<R: RawTx>(

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -27,8 +27,6 @@ pub extern crate jsonrpc;
 pub extern crate bitcoincore_rpc_json;
 pub use crate::json::bitcoin;
 pub use bitcoincore_rpc_json as json;
-use json::bitcoin::consensus::{Decodable, ReadExt};
-use json::bitcoin::hashes::hex::HexIterator;
 
 mod client;
 mod error;
@@ -37,15 +35,3 @@ mod queryable;
 pub use crate::client::*;
 pub use crate::error::Error;
 pub use crate::queryable::*;
-
-fn deserialize_hex<T: Decodable>(hex: &str) -> Result<T> {
-    let mut reader = HexIterator::new(&hex)?;
-    let object = Decodable::consensus_decode(&mut reader)?;
-    if reader.read_u8().is_ok() {
-        Err(Error::BitcoinSerialization(bitcoin::consensus::encode::Error::ParseFailed(
-            "data not consumed entirely when explicitly deserializing",
-        )))
-    } else {
-        Ok(object)
-    }
-}

--- a/client/src/queryable.rs
+++ b/client/src/queryable.rs
@@ -28,7 +28,7 @@ impl<C: RpcApi> Queryable<C> for bitcoin::block::Block {
     fn query(rpc: &C, id: &Self::Id) -> Result<Self> {
         let rpc_name = "getblock";
         let hex: String = rpc.call(rpc_name, &[serde_json::to_value(id)?, 0.into()])?;
-        let bytes: Vec<u8> = bitcoin::hashes::hex::FromHex::from_hex(&hex)?;
+        let bytes: Vec<u8> = bitcoin::hex::FromHex::from_hex(&hex)?;
         Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
     }
 }
@@ -39,7 +39,7 @@ impl<C: RpcApi> Queryable<C> for bitcoin::transaction::Transaction {
     fn query(rpc: &C, id: &Self::Id) -> Result<Self> {
         let rpc_name = "getrawtransaction";
         let hex: String = rpc.call(rpc_name, &[serde_json::to_value(id)?])?;
-        let bytes: Vec<u8> = bitcoin::hashes::hex::FromHex::from_hex(&hex)?;
+        let bytes: Vec<u8> = bitcoin::hex::FromHex::from_hex(&hex)?;
         Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
     }
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -24,11 +24,12 @@ use bitcoincore_rpc::{Auth, Client, Error, RpcApi};
 
 use crate::json::BlockStatsFields as BsFields;
 use bitcoin::consensus::encode::{deserialize, serialize_hex};
-use bitcoin::hashes::hex::FromHex;
+use bitcoin::hex::FromHex;
 use bitcoin::hashes::Hash;
 use bitcoin::{secp256k1, ScriptBuf, sighash};
+use bitcoin::address::{Address, NetworkUnchecked};
 use bitcoin::{
-    Address, Amount, Network, OutPoint, PrivateKey,
+    Amount, Network, OutPoint, PrivateKey, 
     Sequence, SignedAmount, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use bitcoincore_rpc::bitcoincore_rpc_json::{
@@ -596,7 +597,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
             witness: Witness::new(),
         }],
         output: vec![TxOut {
-            value: (unspent.amount - *FEE).to_sat(),
+            value: (unspent.amount - *FEE),
             script_pubkey: addr.script_pubkey(),
         }],
     };
@@ -625,7 +626,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
             witness: Witness::new(),
         }],
         output: vec![TxOut {
-            value: (unspent.amount - *FEE - *FEE).to_sat(),
+            value: (unspent.amount - *FEE - *FEE),
             script_pubkey: RANDOM_ADDRESS.script_pubkey(),
         }],
     };
@@ -1369,7 +1370,7 @@ fn test_add_multisig_address(cl: &Client) {
 
 fn test_derive_addresses(cl: &Client) {
     let descriptor = r"pkh(02e96fe52ef0e22d2f131dd425ce1893073a3c6ad20e8cac36726393dfb4856a4c)#62k9sn4x";
-    assert_eq!(cl.derive_addresses(descriptor, None).unwrap(), vec!["mrkwtj5xpYQjHeJe5wsweNjVeTKkvR5fCr".parse().unwrap()]);
+    assert_eq!(cl.derive_addresses(descriptor, None).unwrap(), vec!["mrkwtj5xpYQjHeJe5wsweNjVeTKkvR5fCr".parse::<Address<NetworkUnchecked>>().unwrap()]);
     assert!(cl.derive_addresses(descriptor, Some([0, 1])).is_err()); // Range should not be specified for an unranged descriptor
 
     let descriptor = std::concat!(
@@ -1377,8 +1378,8 @@ fn test_derive_addresses(cl: &Client) {
         r"tvaRmVyr8Ddf7SjZ2ZfMx9RicjYAXhuh3fmLiVLPodPEqnQQURUfrBKiiVZc8/0/*)#g8l47ngv",
     );
     assert_eq!(cl.derive_addresses(descriptor, Some([0, 1])).unwrap(), vec![
-        "bcrt1q5n5tjkpva8v5s0uadu2y5f0g7pn4h5eqaq2ux2".parse().unwrap(),
-        "bcrt1qcgl303ht03ja2e0hudpwk7ypcxk5t478wspzlt".parse().unwrap(),
+        "bcrt1q5n5tjkpva8v5s0uadu2y5f0g7pn4h5eqaq2ux2".parse::<Address<NetworkUnchecked>>().unwrap(),
+        "bcrt1qcgl303ht03ja2e0hudpwk7ypcxk5t478wspzlt".parse::<Address<NetworkUnchecked>>().unwrap(),
     ]);
     assert!(cl.derive_addresses(descriptor, None).is_err()); // Range must be specified for a ranged descriptor
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::block::Version;
 use bitcoin::consensus::encode;
-use bitcoin::hashes::hex::FromHex;
+use bitcoin::hex::FromHex;
 use bitcoin::hashes::sha256;
 use bitcoin::{Address, Amount, PrivateKey, PublicKey, SignedAmount, Transaction, ScriptBuf, Script, bip158, bip32, Network};
 use serde::de::Error as SerdeError;
@@ -41,8 +41,7 @@ use std::fmt;
 ///
 /// The module is compatible with the serde attribute.
 pub mod serde_hex {
-    use bitcoin::hashes::hex::FromHex;
-    use bitcoin_private::hex::exts::DisplayHex;
+    use bitcoin::hex::{FromHex, DisplayHex};
     use serde::de::Error;
     use serde::{Deserializer, Serializer};
 
@@ -56,8 +55,7 @@ pub mod serde_hex {
     }
 
     pub mod opt {
-        use bitcoin::hashes::hex::FromHex;
-        use bitcoin_private::hex::exts::DisplayHex;
+        use bitcoin::hex::{FromHex, DisplayHex};
         use serde::de::Error;
         use serde::{Deserializer, Serializer};
 


### PR DESCRIPTION
Upgrade the `bitcoin` dependency to the soon-to-be-released version.

Doing this patch lead to:

- https://github.com/rust-bitcoin/rust-bitcoin/pull/2038
- https://github.com/rust-bitcoin/rust-bitcoin/pull/2039

Once they merge and we release then this PR can come off WIP.


Done on top of bitcoin master branch while on commit: `7fd9b89e Merge rust-bitcoin/rust-bitcoin#2010: Use weight type for stripped_size` with the addition of the two PRs above.