### PR TITLE
Upgrade bitcoin

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,7 +27,7 @@ jsonrpc = "0.14.0"
 # Used for deserialization of JSON.
 serde = "1"
 serde_json = "1"
-bitcoin-private = "0.1.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"
+

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use std::{fmt, result};
 
 use crate::{bitcoin, deserialize_hex};
-use bitcoin_private::hex::exts::DisplayHex;
+use bitcoin::hex::DisplayHex;
 use jsonrpc;
 use serde;
 use serde_json;

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -20,7 +20,7 @@ use serde_json;
 #[derive(Debug)]
 pub enum Error {
     JsonRpc(jsonrpc::error::Error),
-    Hex(hex::Error),
+    Hex(hex::HexToBytesError),
     Json(serde_json::error::Error),
     BitcoinSerialization(bitcoin::consensus::encode::Error),
     Secp256k1(secp256k1::Error),
@@ -39,8 +39,8 @@ impl From<jsonrpc::error::Error> for Error {
     }
 }
 
-impl From<hex::Error> for Error {
-    fn from(e: hex::Error) -> Error {
+impl From<hex::HexToBytesError> for Error {
+    fn from(e: hex::HexToBytesError) -> Error {
         Error::Hex(e)
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -28,7 +28,7 @@ pub extern crate bitcoincore_rpc_json;
 pub use crate::json::bitcoin;
 pub use bitcoincore_rpc_json as json;
 use json::bitcoin::consensus::{Decodable, ReadExt};
-use json::bitcoin::hashes::hex::HexIterator;
+use json::bitcoin::hex::HexToBytesIter;
 
 mod client;
 mod error;
@@ -39,7 +39,7 @@ pub use crate::error::Error;
 pub use crate::queryable::*;
 
 fn deserialize_hex<T: Decodable>(hex: &str) -> Result<T> {
-    let mut reader = HexIterator::new(&hex)?;
+    let mut reader = HexToBytesIter::new(&hex)?;
     let object = Decodable::consensus_decode(&mut reader)?;
     if reader.read_u8().is_ok() {
         Err(Error::BitcoinSerialization(bitcoin::consensus::encode::Error::ParseFailed(

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 bitcoincore-rpc = { path = "../client" }
-bitcoin = { version = "0.30.0", features = ["serde", "rand"]}
+bitcoin = { version = "0.31.0", features = ["serde", "rand"]}
 lazy_static = "1.4.0"
 log = "0.4"

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use bitcoin::absolute::LockTime;
-use bitcoin::address::NetworkChecked;
+use bitcoin::address::{NetworkChecked, NetworkUnchecked};
 use bitcoincore_rpc::json;
 use bitcoincore_rpc::jsonrpc::error::Error as JsonRpcError;
 use bitcoincore_rpc::{Auth, Client, Error, RpcApi};
@@ -28,8 +28,8 @@ use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::Hash;
 use bitcoin::{secp256k1, ScriptBuf, sighash};
 use bitcoin::{
-    Address, Amount, Network, OutPoint, PrivateKey,
-    Sequence, SignedAmount, Transaction, TxIn, TxOut, Txid, Witness,
+    transaction, Address, Amount, Network, OutPoint, PrivateKey, Sequence, SignedAmount,
+    Transaction, TxIn, TxOut, Txid, Witness,
 };
 use bitcoincore_rpc::bitcoincore_rpc_json::{
     GetBlockTemplateModes, GetBlockTemplateRules, ScanTxOutRequest,
@@ -584,7 +584,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
     let unspent = unspent.into_iter().nth(0).unwrap();
 
     let tx = Transaction {
-        version: 1,
+        version: transaction::Version::ONE,
         lock_time: LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
@@ -596,7 +596,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
             witness: Witness::new(),
         }],
         output: vec![TxOut {
-            value: (unspent.amount - *FEE).to_sat(),
+            value: (unspent.amount - *FEE),
             script_pubkey: addr.script_pubkey(),
         }],
     };
@@ -613,7 +613,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
     let txid = cl.send_raw_transaction(&res.transaction().unwrap()).unwrap();
 
     let tx = Transaction {
-        version: 1,
+        version: transaction::Version::ONE,
         lock_time: LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
@@ -625,7 +625,7 @@ fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
             witness: Witness::new(),
         }],
         output: vec![TxOut {
-            value: (unspent.amount - *FEE - *FEE).to_sat(),
+            value: (unspent.amount - *FEE - *FEE),
             script_pubkey: RANDOM_ADDRESS.script_pubkey(),
         }],
     };
@@ -1367,9 +1367,13 @@ fn test_add_multisig_address(cl: &Client) {
     assert!(cl.add_multisig_address(addresses.len(), &addresses, None, Some(json::AddressType::Bech32)).is_ok());
 }
 
+#[rustfmt::skip]
 fn test_derive_addresses(cl: &Client) {
     let descriptor = r"pkh(02e96fe52ef0e22d2f131dd425ce1893073a3c6ad20e8cac36726393dfb4856a4c)#62k9sn4x";
-    assert_eq!(cl.derive_addresses(descriptor, None).unwrap(), vec!["mrkwtj5xpYQjHeJe5wsweNjVeTKkvR5fCr".parse().unwrap()]);
+    assert_eq!(
+        cl.derive_addresses(descriptor, None).unwrap(),
+        vec!["mrkwtj5xpYQjHeJe5wsweNjVeTKkvR5fCr".parse::<Address<NetworkUnchecked>>().unwrap()]
+    );
     assert!(cl.derive_addresses(descriptor, Some([0, 1])).is_err()); // Range should not be specified for an unranged descriptor
 
     let descriptor = std::concat!(
@@ -1377,8 +1381,8 @@ fn test_derive_addresses(cl: &Client) {
         r"tvaRmVyr8Ddf7SjZ2ZfMx9RicjYAXhuh3fmLiVLPodPEqnQQURUfrBKiiVZc8/0/*)#g8l47ngv",
     );
     assert_eq!(cl.derive_addresses(descriptor, Some([0, 1])).unwrap(), vec![
-        "bcrt1q5n5tjkpva8v5s0uadu2y5f0g7pn4h5eqaq2ux2".parse().unwrap(),
-        "bcrt1qcgl303ht03ja2e0hudpwk7ypcxk5t478wspzlt".parse().unwrap(),
+        "bcrt1q5n5tjkpva8v5s0uadu2y5f0g7pn4h5eqaq2ux2".parse::<Address<NetworkUnchecked>>().unwrap(),
+        "bcrt1qcgl303ht03ja2e0hudpwk7ypcxk5t478wspzlt".parse::<Address<NetworkUnchecked>>().unwrap(),
     ]);
     assert!(cl.derive_addresses(descriptor, None).is_err()); // Range must be specified for a ranged descriptor
 }

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -22,5 +22,4 @@ path = "src/lib.rs"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 
-bitcoin = { version = "0.30.0", features = ["serde", "rand-std"]}
-bitcoin-private = "0.1.0"
+bitcoin = { version = "0.31.0", features = ["serde", "rand-std"]}

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -41,8 +41,7 @@ use std::fmt;
 ///
 /// The module is compatible with the serde attribute.
 pub mod serde_hex {
-    use bitcoin::hashes::hex::FromHex;
-    use bitcoin_private::hex::exts::DisplayHex;
+    use bitcoin::hex::{DisplayHex, FromHex};
     use serde::de::Error;
     use serde::{Deserializer, Serializer};
 
@@ -56,8 +55,7 @@ pub mod serde_hex {
     }
 
     pub mod opt {
-        use bitcoin::hashes::hex::FromHex;
-        use bitcoin_private::hex::exts::DisplayHex;
+        use bitcoin::hex::{DisplayHex, FromHex};
         use serde::de::Error;
         use serde::{Deserializer, Serializer};
 
@@ -174,7 +172,7 @@ pub struct GetWalletInfoResult {
     #[serde(rename = "paytxfee", with = "bitcoin::amount::serde::as_btc")]
     pub pay_tx_fee: Amount,
     #[serde(rename = "hdseedid")]
-    pub hd_seed_id: Option<bitcoin::hash_types::XpubIdentifier>,
+    pub hd_seed_id: Option<bitcoin::bip32::XKeyIdentifier>,
     pub private_keys_enabled: bool,
     pub avoid_reuse: Option<bool>,
     pub scanning: Option<ScanningDetails>,
@@ -944,7 +942,7 @@ pub struct GetAddressInfoResultEmbedded {
     #[serde(rename = "hdkeypath")]
     pub hd_key_path: Option<bip32::DerivationPath>,
     #[serde(rename = "hdseedid")]
-    pub hd_seed_id: Option<bitcoin::hash_types::XpubIdentifier>,
+    pub hd_seed_id: Option<bitcoin::bip32::XKeyIdentifier>,
     #[serde(default)]
     pub labels: Vec<GetAddressInfoResultLabel>,
 }
@@ -998,7 +996,7 @@ pub struct GetAddressInfoResult {
     #[serde(rename = "hdkeypath")]
     pub hd_key_path: Option<bip32::DerivationPath>,
     #[serde(rename = "hdseedid")]
-    pub hd_seed_id: Option<bitcoin::hash_types::XpubIdentifier>,
+    pub hd_seed_id: Option<bitcoin::bip32::XKeyIdentifier>,
     pub labels: Vec<GetAddressInfoResultLabel>,
     /// Deprecated in v0.20.0. See `labels` field instead.
     #[deprecated(note = "since Core v0.20.0")]


### PR DESCRIPTION
Upgrade `rust-bitcoin` dependency to the newly release v0.31.0. This is needed so we can update `bitcoind` and then `rust-miniscript` to use the new `bitcoin` release.

