### PR TITLE
Bump MSRV to 1.48

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
                     - rust: nightly
                       env:
                           RUSTFMTCHK: false
-                    - rust: 1.41.1
+                    - rust: 1.48.0
                       env:
                           RUSTFMTCHK: false
         steps:
@@ -27,7 +27,6 @@ jobs:
                   profile: minimal
                   toolchain: ${{ matrix.rust }}
                   override: true
-            - run: cargo update -p serde --precise 1.0.152
             - name: Running test script
               env: ${{ matrix.env }}
               run: ./contrib/test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- MSRV changed from 1.41.1 to 1.48.0
+
 # 0.17.0
 
 - add `list_wallet_dir` rpc

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ The following versions are officially supported and automatically tested:
 * 0.21.0
 
 # Minimum Supported Rust Version (MSRV)
-This library should always compile with any combination of features on **Rust 1.41.1**.
+This library should always compile with any combination of features on **Rust 1.48.0**.

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,8 @@
 
 set -xe
 
+MSRV="1\.48"
+
 # Just echo all the relevant env vars to help debug Travis.
 echo "RUSTFMTCHECK: \"$RUSTFMTCHECK\""
 echo "BITCOINVERSION: \"$BITCOINVERSION\""
@@ -9,6 +11,15 @@ echo "PATH: \"$PATH\""
 if [ -n "$RUSTFMTCHECK" ]; then
   rustup component add rustfmt
   cargo fmt --all -- --check
+fi
+
+# Test pinned versions (these are from rust-bitcoin pinning for 1.48).
+if cargo --version | grep ${MSRV}; then
+    cargo update -p log --precise 0.4.18
+    cargo update -p serde_json --precise 1.0.99
+    cargo update -p serde --precise 1.0.156
+    cargo update -p quote --precise 1.0.30
+    cargo update -p proc-macro2 --precise 1.0.63
 fi
 
 # Integration test.


### PR DESCRIPTION
This would allow us to upgrade the `jsonrpc` dep and get `minreq` support possibly alleviating the need for #276. Also required to use the latest `rust-bitcoin`.