### PR TITLE
CI: Pin dependencies for MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,6 @@ jobs:
                   profile: minimal
                   toolchain: ${{ matrix.rust }}
                   override: true
-            - run: cargo update -p serde --precise 1.0.152
             - name: Running test script
               env: ${{ matrix.env }}
               run: ./contrib/test.sh

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,8 @@
 
 set -xe
 
+MSRV="1\.41"
+
 # Just echo all the relevant env vars to help debug Travis.
 echo "RUSTFMTCHECK: \"$RUSTFMTCHECK\""
 echo "BITCOINVERSION: \"$BITCOINVERSION\""
@@ -9,6 +11,15 @@ echo "PATH: \"$PATH\""
 if [ -n "$RUSTFMTCHECK" ]; then
   rustup component add rustfmt
   cargo fmt --all -- --check
+fi
+
+# Test pinned versions (these are from rust-bitcoin pinning for 1.48).
+if cargo --version | grep ${MSRV}; then
+    cargo update -p log --precise 0.4.18
+    cargo update -p serde_json --precise 1.0.99
+    cargo update -p serde --precise 1.0.156
+    cargo update -p quote --precise 1.0.30
+    cargo update -p proc-macro2 --precise 1.0.63
 fi
 
 # Integration test.


### PR DESCRIPTION
Loads of deps break MSRV at the moment because the Rust ecosystem is upgrading to edition 2021 left, right, and centre without bumping crate versions.

Pin various crates in CI for MSRV test run, do it in the CI script instead of in the github action.

I pulled this PR out of #312, the versions are what we use for MSRV 1.48, just pushing this to see if they work because CI is broken without some pinning.