### PR TITLE
Add comment clarifying fee rate in FundRawTransactionOptions

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1877,6 +1877,9 @@ pub struct FundRawTransactionOptions {
     pub include_watching: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lock_unspents: Option<bool>,
+    /// The fee rate to pay per kvB. NB. This field is converted to camelCase
+    /// when serialized, so it is receeived by fundrawtransaction as `feeRate`,
+    /// which fee rate per kvB, and *not* `fee_rate`, which is per vB.
     #[serde(
         with = "bitcoin::amount::serde::as_btc::opt",
         skip_serializing_if = "Option::is_none"


### PR DESCRIPTION
I think this is potentially a bit of a footgun and deserves some clarification.

`fundrawtransaction` has two different ways to specify fee rate, `fee_rate`, and `feeRate`. From [the docs](https://developer.bitcoin.org/reference/rpc/fundrawtransaction.html):

```
"fee_rate" -  Specify a fee rate in sat/vB.
"feeRate" - Specify a fee rate in BTC/kvB.
```

This is extra confusing because the field in FundRawTransactionOptions is called `fee_rate`, but is serde renamed to camelCase, so becomes `feeRate`.

This PR adds a comment to `FundRawTransactionOptions::fee_rate` clarifying that it's in kvB and not vB, and corresponds to the `feeRate` argument to `fundrawtransaction`.

I actually think it would it would probably be best if the rust field were renamed to `fee_rate_per_kvb`, and manually renamed to `feeRate` when serializing, but this is good quick fix.