### PR TITLE
Implement `getblock` with verbosity value `2`

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -21,7 +21,7 @@ use jsonrpc;
 use serde;
 use serde_json;
 
-use crate::bitcoin::address::{NetworkUnchecked, NetworkChecked};
+use crate::bitcoin::address::{NetworkChecked, NetworkUnchecked};
 use crate::bitcoin::hashes::hex::FromHex;
 use crate::bitcoin::secp256k1::ecdsa::Signature;
 use crate::bitcoin::{
@@ -343,7 +343,10 @@ pub trait RpcApi: Sized {
     fn get_block_info(&self, hash: &bitcoin::BlockHash) -> Result<json::GetBlockResult> {
         self.call("getblock", &[into_json(hash)?, 1.into()])
     }
-    //TODO(stevenroose) add getblock_txs
+
+    fn get_block_txs(&self, hash: &bitcoin::BlockHash) -> Result<json::GetBlockTxResult> {
+        self.call("getblock", &[into_json(hash)?, 2.into()])
+    }
 
     fn get_block_header(&self, hash: &bitcoin::BlockHash) -> Result<bitcoin::block::Header> {
         let hex: String = self.call("getblockheader", &[into_json(hash)?, false.into()])?;

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -328,8 +328,8 @@ fn test_get_block(cl: &Client) {
 
     let tip = cl.get_best_block_hash().unwrap();
     let info = cl.get_block_info(&tip).unwrap();
-    assert_eq!(info.hash, tip);
-    assert_eq!(info.confirmations, 1);
+    assert_eq!(info.common.hash, tip);
+    assert_eq!(info.common.confirmations, 1);
 }
 
 fn test_get_block_header_get_block_header_info(cl: &Client) {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -24,15 +24,17 @@ extern crate serde_json;
 
 use std::collections::HashMap;
 
-
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::block::Version;
 use bitcoin::consensus::encode;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::sha256;
-use bitcoin::{Address, Amount, PrivateKey, PublicKey, SignedAmount, Transaction, ScriptBuf, Script, bip158, bip32, Network};
+use bitcoin::{
+    bip158, bip32, Address, Amount, Network, PrivateKey, PublicKey, Script, ScriptBuf,
+    SignedAmount, Transaction,
+};
 use serde::de::Error as SerdeError;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 
 //TODO(stevenroose) consider using a Time type
@@ -193,7 +195,7 @@ impl Eq for ScanningDetails {}
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GetBlockResult {
+pub struct BlockData {
     pub hash: bitcoin::BlockHash,
     pub confirmations: i32,
     pub size: usize,
@@ -204,7 +206,6 @@ pub struct GetBlockResult {
     #[serde(default, with = "crate::serde_hex::opt")]
     pub version_hex: Option<Vec<u8>>,
     pub merkleroot: bitcoin::hash_types::TxMerkleNode,
-    pub tx: Vec<bitcoin::Txid>,
     pub time: usize,
     pub mediantime: Option<usize>,
     pub nonce: u32,
@@ -215,6 +216,44 @@ pub struct GetBlockResult {
     pub n_tx: usize,
     pub previousblockhash: Option<bitcoin::BlockHash>,
     pub nextblockhash: Option<bitcoin::BlockHash>,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlockResult {
+    #[serde(flatten)]
+    pub common: BlockData,
+    pub tx: Vec<bitcoin::Txid>,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetBlockTxResult {
+    #[serde(flatten)]
+    pub common: BlockData,
+    #[serde(deserialize_with = "deserialize_tx")]
+    pub tx: Vec<Transaction>,
+}
+
+fn deserialize_tx<'de, D>(deserializer: D) -> Result<Vec<Transaction>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Debug, Deserialize)]
+    struct TxWrapper {
+        pub hex: String,
+    }
+
+    let tx_wrappers: Vec<TxWrapper> = Deserialize::deserialize(deserializer)?;
+    let transactions: Result<Vec<Transaction>, _> = tx_wrappers
+        .into_iter()
+        .map(|wrapper| {
+            let bytes: Vec<u8> = FromHex::from_hex(&wrapper.hex).unwrap();
+            Ok(bitcoin::consensus::encode::deserialize(&bytes).unwrap())
+        })
+        .collect();
+
+    transactions
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
# Changes

- Add `get_block_txs` method that calls `getblock` with verbosity value `2`
- Add `GetBlockTxResult` struct to `json`
- Utilize composition in `GetBlockResult` and `GetBlockTxResult` to get rid of duplicate fields