### PR TITLE
Bump MSRV to Rust 1.56.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
                     - rust: nightly
                       env:
                           RUSTFMTCHK: false
-                    - rust: 1.48.0
+                    - rust: 1.56.1
                       env:
                           RUSTFMTCHK: false
         steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- MSRV changed from 1.48.0 to 1.56.1
+
 # 0.18.0
 
 - MSRV changed from 1.41.1 to 1.48.0

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ The following versions are officially supported and automatically tested:
 * 0.21.0
 
 # Minimum Supported Rust Version (MSRV)
-This library should always compile with any combination of features on **Rust 1.48.0**.
+This library should always compile with any combination of features on **Rust 1.56.1**.

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,7 +1,7 @@
 
 set -xe
 
-MSRV="1\.48"
+MSRV="1\.56"
 
 # Just echo all the relevant env vars to help debug Travis.
 echo "RUSTFMTCHECK: \"$RUSTFMTCHECK\""
@@ -13,14 +13,10 @@ if [ -n "$RUSTFMTCHECK" ]; then
   cargo fmt --all -- --check
 fi
 
-# Test pinned versions (these are from rust-bitcoin pinning for 1.48).
+# Test pinned versions.
 if cargo --version | grep ${MSRV}; then
     cargo update -p tempfile --precise 3.3.0
     cargo update -p log --precise 0.4.18
-    cargo update -p serde_json --precise 1.0.99
-    cargo update -p serde --precise 1.0.156
-    cargo update -p quote --precise 1.0.30
-    cargo update -p proc-macro2 --precise 1.0.63
 fi
 
 # Integration test.

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc/"
 description = "JSON-enabled type structs for bitcoincore-rpc crate."
 keywords = [ "crypto", "bitcoin", "bitcoin-core", "rpc" ]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.1"
 
 [lib]
 name = "bitcoincore_rpc_json"


### PR DESCRIPTION
As we have done for the rest of the ecosystem; bump the MSRV to Rust `v1.56.1` - enables edition 2021.