### PR TITLE
Use minreq_http feature of jsonrpc

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -223,6 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
  "base64",
+ "minreq",
  "serde",
  "serde_json",
 ]
@@ -250,6 +251,17 @@ name = "log"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+
+[[package]]
+name = "minreq"
+version = "2.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fdef521c74c2884a4f3570bcdb6d2a77b3c533feb6b27ac2ae72673cc221c64"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -223,6 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
  "base64",
+ "minreq",
  "serde",
  "serde_json",
 ]
@@ -250,6 +251,17 @@ name = "log"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+
+[[package]]
+name = "minreq"
+version = "2.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fdef521c74c2884a4f3570bcdb6d2a77b3c533feb6b27ac2ae72673cc221c64"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 bitcoincore-rpc-json = { version = "0.18.0", path = "../json" }
 
 log = "0.4.5"
-jsonrpc = { version = "0.18.0", features = [] }
+jsonrpc = { version = "0.18.0", features = ["minreq_http"] }
 
 # Used for deserialization of JSON.
 serde = "1"


### PR DESCRIPTION
Recently in `jsonrpc` we added an HTTP client that uses `minreq`. Since we now use a version of `jsonrpc` with this feature we can now use `minreq` here.
