### PR TITLE
Add verifymessage feature

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,6 +18,9 @@ edition = "2018"
 name = "bitcoincore_rpc"
 path = "src/lib.rs"
 
+[features]
+verifymessage = ["bitcoincore-rpc-json/verifymessage"]
+
 [dependencies]
 bitcoincore-rpc-json = { version = "0.18.0", path = "../json" }
 
@@ -31,3 +34,10 @@ serde_json = "1"
 [dev-dependencies]
 tempfile = "3.3.0"
 
+[[example]]
+name = "retry_client"
+required-features = ["verifymessage"]
+
+[[example]]
+name = "test_against_node"
+required-features = []

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -23,6 +23,7 @@ use serde_json;
 
 use crate::bitcoin::address::{NetworkUnchecked, NetworkChecked};
 use crate::bitcoin::hashes::hex::FromHex;
+#[cfg(feature = "verifymessage")]
 use bitcoin::sign_message::MessageSignature;
 use crate::bitcoin::{
     Address, Amount, Block, OutPoint, PrivateKey, PublicKey, Script, Transaction,
@@ -871,6 +872,7 @@ pub trait RpcApi: Sized {
         self.call("stop", &[])
     }
 
+    #[cfg(feature = "verifymessage")]
     fn verify_message(
         &self,
         address: &Address,

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -16,7 +16,10 @@ fi
 # Test pinned versions.
 if cargo --version | grep ${MSRV}; then
     cargo update -p tempfile --precise 3.3.0
+    cargo update -p cc --precise 1.0.79
     cargo update -p log --precise 0.4.18
+    cargo update -p serde_json --precise 1.0.96
+    cargo update -p serde --precise 1.0.156
 fi
 
 # Integration test.

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Steven Roose <steven@stevenroose.org>"]
 edition = "2018"
 
 [dependencies]
-bitcoincore-rpc = { path = "../client" }
+bitcoincore-rpc = { path = "../client", features = ["verifymessage"] }
 bitcoin = { version = "0.31.0", features = ["serde", "rand", "base64"]}
 lazy_static = "1.4.0"
 log = "0.4"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -19,6 +19,9 @@ rust-version = "1.56.1"
 name = "bitcoincore_rpc_json"
 path = "src/lib.rs"
 
+[features]
+verifymessage = ["bitcoin/base64"]
+
 [dependencies]
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"


### PR DESCRIPTION
- Patch 1: Adds new feature "verifymessage" fixing by broken master branch.
- Patch 2: Fixes pinning allowing this PR to get past CI. 

---

In #326 we changed a function to use `bitcoin::sign_message::MessageSignature` but doing so requires the "base64" feature to be on for `bitcoin`. This did not get caught by CI but improvements to CI in #338 will now catch this.

Add a feature to `json` and `client` that allows enabling "base64" if the `verifymessage` RPC call is required.