### PR TITLE
json: Enable "base64" feature

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -16,7 +16,10 @@ fi
 # Test pinned versions.
 if cargo --version | grep ${MSRV}; then
     cargo update -p tempfile --precise 3.3.0
+    cargo update -p cc --precise 1.0.79
     cargo update -p log --precise 0.4.18
+    cargo update -p serde_json --precise 1.0.96
+    cargo update -p serde --precise 1.0.156
 fi
 
 # Integration test.

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -23,4 +23,4 @@ path = "src/lib.rs"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 
-bitcoin = { version = "0.31.0", features = ["serde", "rand-std"]}
+bitcoin = { version = "0.31.0", features = ["serde", "rand-std", "base64"]}


### PR DESCRIPTION
We need base64 encoding in `bitcoin` to in order to stringify the `sign_message::MessageSignature`.
    
Note also that the `Psbt` type is encoded/decoded in base64 and we would  like to support that by default also.
    
Enable the "base64" feature unconditionally for the `json` crate.

(Patch 2 fixes pinning MSRV which is currently broken on master.)