### PR TITLE
Revert "Merge rust-bitcoin/rust-bitcoincore-rpc#326: Replace Signatur…

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -23,7 +23,7 @@ use serde_json;
 
 use crate::bitcoin::address::{NetworkUnchecked, NetworkChecked};
 use crate::bitcoin::hashes::hex::FromHex;
-use bitcoin::sign_message::MessageSignature;
+use crate::bitcoin::secp256k1::ecdsa::Signature;
 use crate::bitcoin::{
     Address, Amount, Block, OutPoint, PrivateKey, PublicKey, Script, Transaction,
 };
@@ -874,7 +874,7 @@ pub trait RpcApi: Sized {
     fn verify_message(
         &self,
         address: &Address,
-        signature: &MessageSignature,
+        signature: &Signature,
         message: &str,
     ) -> Result<bool> {
         let args = [address.to_string().into(), signature.to_string().into(), into_json(message)?];

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 bitcoincore-rpc = { path = "../client" }
-bitcoin = { version = "0.31.0", features = ["serde", "rand", "base64"]}
+bitcoin = { version = "0.31.0", features = ["serde", "rand"]}
 lazy_static = "1.4.0"
 log = "0.4"

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -26,7 +26,6 @@ use crate::json::BlockStatsFields as BsFields;
 use bitcoin::consensus::encode::{deserialize, serialize_hex};
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::Hash;
-use bitcoin::sign_message::MessageSignature;
 use bitcoin::{secp256k1, ScriptBuf, sighash};
 use bitcoin::{
     transaction, Address, Amount, Network, OutPoint, PrivateKey, Sequence, SignedAmount,
@@ -147,7 +146,6 @@ fn main() {
     test_get_blockchain_info(&cl);
     test_get_new_address(&cl);
     test_get_raw_change_address(&cl);
-    test_verify_message_with_messagesignature(&cl);
     test_dump_private_key(&cl);
     test_generate(&cl);
     test_get_balance_generate_to_address(&cl);
@@ -218,7 +216,7 @@ fn main() {
     test_get_mempool_info(&cl);
     test_add_multisig_address(&cl);
     //TODO import_multi(
-
+    //TODO verify_message(
     //TODO encrypt_wallet(&self, passphrase: &str) -> Result<()> {
     //TODO get_by_id<T: queryable::Queryable<Self>>(
     test_add_node(&cl);
@@ -1368,16 +1366,6 @@ fn test_add_multisig_address(cl: &Client) {
     assert!(cl.add_multisig_address(addresses.len(), &addresses, None, Some(json::AddressType::Legacy)).is_ok());
     assert!(cl.add_multisig_address(addresses.len(), &addresses, None, Some(json::AddressType::P2shSegwit)).is_ok());
     assert!(cl.add_multisig_address(addresses.len(), &addresses, None, Some(json::AddressType::Bech32)).is_ok());
-}
-
-fn test_verify_message_with_messagesignature(cl: &Client) {
-    let addr: Address = Address::from_str("mm68FdwbpxkVcqjU3fu7iiBGEwrsC6Hk66").unwrap().assume_checked();  
-    let signature = MessageSignature::from_base64(
-        "H3X+ic7axKtHGIsKiqDq0TmP9HIAkONwunln17ROlvB4SOVVUoG5e79EwAz94x2eERPwqcGJ5rLuWRhIu85pEwE=",)
-        .expect("a valid signature");
-    let message = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks";
-
-    assert!(cl.verify_message(&addr, &signature, message).expect("a valid signature")); 
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
…e with Message Signature"

This reverts commit 05f5b82373c3e52ad675694113780b43418a6917, reversing changes made to c0fc7cbd98400d6816f5f9d4b805de4963a5c734.

#326 was broken, I should never have merged it. It also should never have gotten past CI. All blame falls on me.