### PR TITLE
CI: Fix pinning

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -16,7 +16,10 @@ fi
 # Test pinned versions.
 if cargo --version | grep ${MSRV}; then
     cargo update -p tempfile --precise 3.3.0
+    cargo update -p cc --precise 1.0.79
     cargo update -p log --precise 0.4.18
+    cargo update -p serde_json --precise 1.0.96
+    cargo update -p serde --precise 1.0.156
 fi
 
 # Integration test.


### PR DESCRIPTION
MSRV build just broke because of a bunch of dependencies. I did not investigate why I just found a set of versions that builds.

There are more CI fixes in the wind, this just makes the MSRV job pass because all PRs are currently held up by the failing job.
