### PR TITLE
Allow warnings to be either a string or a string sequence.

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1003,6 +1003,14 @@ pub struct GetAddressInfoResult {
     pub label: Option<String>,
 }
 
+/// Used to represent values that can either be a string or a string array.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StringOrStringArray {
+	String(String),
+	StringArray(Vec<String>),
+}
+
 /// Models the result of "getblockchaininfo"
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GetBlockchainInfoResult {
@@ -1044,8 +1052,8 @@ pub struct GetBlockchainInfoResult {
     /// Status of softforks in progress
     #[serde(default)]
     pub softforks: HashMap<String, Softfork>,
-    /// Any network and blockchain warnings.
-    pub warnings: String,
+    /// Any network and blockchain warnings. In later versions of bitcoind, it's an array of strings.
+    pub warnings: StringOrStringArray,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]


### PR DESCRIPTION
In recent versions of bitcoind, `getblockchaininfo` returns a result whose `warnings` key is no longer a string, but an array of strings. This PR allows the parsing of either. Fixes #352.