### PR TITLE
Allow deprecated in main lib module

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![crate_name = "bitcoincore_rpc_json"]
 #![crate_type = "rlib"]
+#![allow(deprecated)]           // Because of `GetPeerInfoResultNetwork::Unroutable`.
 
 pub extern crate bitcoin;
 #[allow(unused)]


### PR DESCRIPTION
We deprecate a variant in `GetPeerInfoResultNetwork` that causes clippy to give a false positive. Adding an attribute on the enum does not quitet it down, just add a module level attribute.

This warning has been here for ever.