### PR TITLE
Support multiple warnings in RPC responses

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -118,7 +118,7 @@ pub struct GetNetworkInfoResult {
     pub incremental_fee: Amount,
     #[serde(rename = "localaddresses")]
     pub local_addresses: Vec<GetNetworkInfoResultAddress>,
-    pub warnings: String,
+    pub warnings: StringOrStringArray,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
@@ -517,7 +517,7 @@ pub struct GetMiningInfoResult {
     pub pooled_tx: usize,
     #[serde(deserialize_with = "deserialize_bip70_network")]
     pub chain: Network,
-    pub warnings: String,
+    pub warnings: StringOrStringArray,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
@@ -1005,7 +1005,7 @@ pub struct GetAddressInfoResult {
 }
 
 /// Used to represent values that can either be a string or a string array.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub enum StringOrStringArray {
 	String(String),


### PR DESCRIPTION
Following https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/353.

Tested on latest bitcoind (https://github.com/bitcoin/bitcoin/commit/2cedb42a928fbf3a1e0e8715e918497cbe64af0d) with latest electrs (https://github.com/romanz/electrs/commit/7773c266d108463202bb4bc271dedfbc0b80673a).