### PR TITLE
Add dumptxoutset

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1267,6 +1267,16 @@ pub trait RpcApi: Sized {
     fn get_zmq_notifications(&self) -> Result<Vec<json::GetZmqNotificationsResult>> {
         self.call("getzmqnotifications", &[])
     }
+
+    /// Write the serialized UTXO set to a file.
+    /// If used to dump the UTXO set of the mainnet, make sure you create a client through
+    /// bitcoincore_rpc::jsonrpc::simple_http::Builder, so that the timeout can be set to a 
+    /// higher level compared to the default value. Since it takes a considerable time for 
+    /// bitcoincore to dump the UTXO set, if bitcoincore_rpc::Client::new is used, you will 
+    /// encounter a timeout error.
+    fn dump_tx_out_set(&self, path: &str) -> Result<json::DumpTxOutSetResult> {
+        self.call("dumptxoutset", &[path.into()])
+    }
 }
 
 /// Client implements a JSON-RPC client for the Bitcoin Core daemon or compatible APIs.

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -14,6 +14,7 @@
 extern crate lazy_static;
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use bitcoin::absolute::LockTime;
@@ -227,6 +228,7 @@ fn main() {
     test_set_network_active(&cl);
     test_get_index_info(&cl);
     test_get_zmq_notifications(&cl);
+    test_dump_tx_out_set(&cl);
     test_stop(cl);
 }
 
@@ -1457,6 +1459,12 @@ fn test_get_zmq_notifications(cl: &Client) {
                 },
             ]
     );
+}
+
+fn test_dump_tx_out_set(cl: &Client) {
+    let dump_file_path = format!("{}/utxo_dump.dat", get_testdir());
+    let _dump_result = cl.dump_tx_out_set(&dump_file_path).unwrap();
+    assert!(PathBuf::from_str(&dump_file_path).unwrap().exists())
 }
 
 fn test_stop(cl: Client) {

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2160,6 +2160,24 @@ pub struct GetZmqNotificationsResult {
     pub hwm: u64,
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct DumpTxOutSetResult {
+    /// The number of coins written in the snapshot
+    pub coins_written: u64,
+    /// The hash of the base of the snapshot
+    pub base_hash: bitcoin::BlockHash,
+    /// The height of the base of the snapshot
+    pub base_height: u64,
+    /// The absolute path that the snapshot was written to
+    pub path: String,
+    /// The hash of the UTXO set contents
+    #[serde(rename = "txoutset_hash")]
+    pub tx_out_set_hash: sha256::Hash,
+    /// The number of transactions in the chain up to and including the base block
+    #[serde(rename = "nchaintx")]
+    pub number_chain_tx: u64,
+}
+
 impl<'a> serde::Serialize for PubKeyOrAddress<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Added dumptxout rpc call. 
This call encounters `JsonRpc(Transport(SocketError(Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" })))` error if used on a default client connected to mainnet due to the time it takes to complete the process.
Simple workaround consists of creating the client through `bitcoincore_rpc::jsonrpc::simple_http::Builder` with an increased `timeout` parameter.
It must be noted that the aforementioned rpc error does not affect the process of creating the dump file by bitcoin.