### PR TITLE
fix deprecations in the std::error::Error trait impl

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -93,11 +93,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        "bitcoincore-rpc error"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             Error::JsonRpc(ref e) => Some(e),
             Error::Hex(ref e) => Some(e),


### PR DESCRIPTION
`cause` is deprecated in favor of `source`, calls to `cause` are redirected there
`description` is also deprecated because it is generally uninformative (the return value lifetime is very restrictive), this is replaced by the Display trait (already implemented)