### PR TITLE
feat/fix: add new `Client` builder method with an arbitrary timeout value & add new method for `scantxoutset status`

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1272,6 +1272,11 @@ pub trait RpcApi: Sized {
             Err(e) => Err(e),
         }
     }
+
+    // Abort a UTXO set scan
+    fn scan_tx_out_set_abort(&self) -> Result<bool> {
+        self.call("scantxoutset", &["abort".into()])
+    }
     
     fn scan_tx_out_set_blocking(
         &self,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1257,6 +1257,22 @@ pub trait RpcApi: Sized {
         }
     }
 
+    // Return the status of a UTXO set scan
+    fn scan_tx_out_set_status(&self) -> Result<Option<json::ScanTxOutStatusResult>> {
+        match self.call("scantxoutset", &["status".into()]) {
+            Ok(response) => {
+                let response: serde_json::Value = response;
+                if response.is_null() {
+                    Ok(None)
+                } else {
+                    let result: json::ScanTxOutStatusResult = serde_json::from_value(response)?;
+                    Ok(Some(result))
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+    
     fn scan_tx_out_set_blocking(
         &self,
         descriptors: &[json::ScanTxOutRequest],

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -14,6 +14,7 @@ use std::io::{BufRead, BufReader};
 use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::{fmt, result};
+use std::time::Duration;
 
 use crate::bitcoin;
 use crate::bitcoin::consensus::encode;
@@ -1291,6 +1292,28 @@ impl Client {
                 client,
             })
             .map_err(|e| super::error::Error::JsonRpc(e.into()))
+    }
+
+    /// Creates a client to a bitcoind JSON-RPC server with a custom timeout value, in seconds.
+    /// Useful when making an RPC that can take a long time e.g. scantxoutset
+    pub fn new_with_custom_timeout(url: &str, auth: Auth, timeout: u64) -> result::Result<Self, Error> {
+        let (user, pass) = auth.get_user_pass()?;
+
+        let user = user.unwrap();
+        let pass = pass.unwrap();
+
+        let transport =
+            jsonrpc::simple_http::Builder::new()
+            .timeout(Duration::from_secs(timeout))
+            .url(url)
+            .unwrap()
+            .auth(user, Some(pass))
+            .build();
+
+        let client = jsonrpc::client::Client::with_transport(transport);
+
+        Ok(Client{ client })
+
     }
 
     /// Create a new Client using the given [jsonrpc::Client].

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2097,6 +2097,12 @@ pub enum PubKeyOrAddress<'a> {
     PubKey(&'a PublicKey),
 }
 
+/// Used to represent the status of a UTXO set scan.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct ScanTxOutStatusResult {
+    pub progress: u8,
+}
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(untagged)]
 /// Start a scan of the UTXO set for an [output descriptor](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).


### PR DESCRIPTION
This PR fixes #361 by creating a new buider method for `Client`, namely `new_with_custom_timeout()`, that adds a new `timeout` parameter relative to `new()`.

This was done mainly to allow RPCs that take longer than 15 seconds as defined in the `rust-jsonrpc` crate.

It's up to the user to define a sensible timeout value.

```rust
let client = Client::new_with_custom_timeout(
                     "127.0.0.1",
                     Auth::UserPass("satoshi".to_string(), "satoshi".to_string()),
                     500
).unwrap();
```