### PR TITLE
chore: add new blockhash and confirmations fields to Utxo struct

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2136,6 +2136,8 @@ pub struct Utxo {
     #[serde(with = "bitcoin::amount::serde::as_btc")]
     pub amount: bitcoin::Amount,
     pub height: u64,
+    pub blockhash: Option<bitcoin::BlockHash>,
+    pub confirmations: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]


### PR DESCRIPTION
As per [PR #30515](https://github.com/bitcoin/bitcoin/pull/30515) on Bitcoin Core, two new fields are added on the output of `scantxoutset` for versions `v28` and above:
- blockhash: blockhash of the UTXO,
- confirmations: number of confirmations of the UTXO.

This PR adds these two new fields on the `Utxo` struct as an `Option`, since not all clients will be running `v28`:
```diff
pub struct Utxo {
    pub txid: bitcoin::Txid,
    pub vout: u32,
    pub script_pub_key: bitcoin::ScriptBuf,
    #[serde(rename = "desc")]
    pub descriptor: String,
    #[serde(with = "bitcoin::amount::serde::as_btc")]
    pub amount: bitcoin::Amount,
    pub height: u64,
+   pub blockhash: Option<bitcoin::BlockHash>,
+   pub confirmations: Option<u64>,
}
```
