### PR TITLE
Add ScriptPubkeyType::Anchor

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -915,6 +915,7 @@ pub enum ScriptPubkeyType {
     Witness_v0_ScriptHash,
     Witness_v1_Taproot,
     Witness_Unknown,
+    Anchor,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
- Add `ScriptPubkeyType::Anchor` to match addition commit [`455fca86cfada1823aa28615b5683f9dc73dbb9a`](https://github.com/bitcoin/bitcoin/commit/455fca86cfada1823aa28615b5683f9dc73dbb9a)

- Required for testnet4 support