### PR TITLE
Add `submitpackage` RPC

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -868,6 +868,22 @@ pub trait RpcApi: Sized {
         self.call("testmempoolaccept", &[hexes.into()])
     }
 
+    /// Submit a package of raw transactions to the node. The package will be
+    /// validated according to consensus and mempool policy rules. If all
+    /// transactions pass, they will be accepted to mempool.
+    fn submit_package<R: RawTx>(
+        &self,
+        rawtxs: &[R],
+        maxfeerate: Option<f64>,
+        maxburnamount: Option<f64>,
+    ) -> Result<json::SubmitPackageResult> {
+        let hexes: Vec<serde_json::Value> =
+            rawtxs.to_vec().into_iter().map(|r| r.raw_hex().into()).collect();
+        let mut args = [hexes.into(), opt_into_json(maxfeerate)?, opt_into_json(maxburnamount)?];
+        let defaults = [null(), null()];
+        self.call("submitpackage", handle_defaults(&mut args, &defaults))
+    }
+
     fn stop(&self) -> Result<String> {
         self.call("stop", &[])
     }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -852,6 +852,56 @@ pub struct TestMempoolAcceptResultFees {
     // unlike GetMempoolEntryResultFees, this only has the `base` fee
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct Fees {
+    /// Transaction fee.
+    #[serde(with = "bitcoin::amount::serde::as_btc")]
+    pub base: Amount,
+
+    /// If the transaction was not already in the mempool, the effective feerate
+    /// in BTC per KvB. For example, the package feerate and/or feerate with
+    /// modified fees from prioritisetransaction.
+    #[serde(default, rename = "effective-feerate", with = "bitcoin::amount::serde::as_btc::opt")]
+    pub effective_feerate: Option<Amount>,
+
+    /// If effective-feerate is provided, the wtxids of the transactions whose
+    /// fees and vsizes are included in effective-feerate.
+    #[serde(rename = "effective-includes")]
+    pub effective_includes: Option<Vec<bitcoin::Wtxid>>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct TxResult {
+    pub txid: bitcoin::Txid,
+
+    /// The wtxid of a different transaction with the same txid but different
+    /// witness found in the mempool. This means the submitted transaction was
+    /// ignored.
+    #[serde(rename = "other-wtxid")]
+    pub other_wtxid: Option<bitcoin::Wtxid>,
+
+    /// Virtual transaction size as defined in BIP 141.
+    pub vsize: Option<u64>,
+
+    pub fees: Option<Fees>,
+
+    pub error: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct SubmitPackageResult {
+    /// The transaction package result message. "success" indicates all transactions were accepted into or are already in the mempool
+    pub package_msg: String,
+
+    /// Transaction results keyed by wtxid.
+    #[serde(rename = "tx-results")]
+    pub tx_results: HashMap<bitcoin::Wtxid, TxResult>,
+
+    /// List of txids of replaced transactions.
+    #[serde(rename = "replaced-transactions")]
+    pub replaced_transactions: Vec<bitcoin::Txid>,
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Bip9SoftforkStatus {


### PR DESCRIPTION
This PR adds `submitpackage` RPC, as per Bitcoin Core 28 API.
Supersedes https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/302, which appears to be unmaintained.