### PR TITLE
Allow importing multiple descriptors with `importdescriptors`

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -667,9 +667,9 @@ pub trait RpcApi: Sized {
 
     fn import_descriptors(
         &self,
-        req: json::ImportDescriptors,
+        req: &[json::ImportDescriptors],
     ) -> Result<Vec<json::ImportMultiResult>> {
-        let json_request = vec![serde_json::to_value(req)?];
+        let json_request = serde_json::to_value(req)?;
         self.call("importdescriptors", handle_defaults(&mut [json_request.into()], &[null()]))
     }
 


### PR DESCRIPTION
Changes `import_descriptors` to accept a slice of `ImportDescriptors`, instead of just one, to allow importing multiple descriptors at once. Tested against Bitcoin Core 28.0.0.